### PR TITLE
Ease creation of custom SPARQL functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ An open-source framework for building SPARQL query engines in Javascript.
 * Build a [SPARQL](https://www.w3.org/TR/2013/REC-sparql11-overview-20130321/) query engine on top of any data storage system.
 * Supports [the full features of the SPARQL syntax](https://www.w3.org/TR/sparql11-query/) by *implementing a single class!*
 * Implements advanced *SPARQL query rewriting techniques* for transparently optimizing SPARQL query processing.
+* Supports [Custom SPARQL functions](#custom-functions).
 * Supports the [SPARQL UPDATE protocol](https://www.w3.org/TR/2013/REC-sparql11-update-20130321/).
 * Supports Basic [Federated SPARQL queries](https://www.w3.org/TR/2013/REC-sparql11-federated-query-20130321/) using **SERVICE clauses**.
 * Customize every step of SPARQL query processing, thanks to a component-based architecture.
@@ -182,41 +183,47 @@ The `sparql-engine` framework provides a supports for declaring such custom func
 
 ## Setp 1: Create a JSON object mapping
 
-A SPARQL custom functions is defined by an `IRI` (or prefixed name) in `FILTER`, `BIND` or `HAVING BY` expressions.
-You must create a JSON object that maps each `IRI` to a function that takes a variable number of [RDFTerms](./src/rdf-terms.ts) and returns an `RDFTerm`.
-Here is a snipped from the working [example](./examples/custom-functions.js).
+A SPARQL value function is an extension point of the SPARQL query language that allows URI to name a function in the query processor.
+It is defined by an `IRI` in a `FILTER`, `BIND` or `HAVING BY` expression.
+To register custom functions, you must create a JSON object that maps each `IRI` to a Javascript function that takes a variable number of [RDFTerms](./src/rdf-terms.ts) arguments and returns an `RDFTerm`.
 See [the `terms` package documentation](https://callidon.github.io/sparql-engine/modules/terms.html) for more details on how to manipulate RDF terms.
 
+The following shows a declaration of some simple custom functions.
 ```javascript
 // load the utility functions used to manipulate RDF terms
 const { terms } = require('sparql-engine')
 
 // define some custom SPARQL functions
 const customFunctions = {
+  // reverse a RDF literal
   'http://example.com#REVERSE': function (rdfTerm) {
     const reverseValue = rdfTerm.value.split("").reverse().join("")
     return terms.replaceLiteralValue(rdfTerm, reverseValue)
   },
+  // Test if a RDF Luteral is a palindrome
   'http://example.com#IS_PALINDROME': function (rdfTerm) {
     const result = rdfTerm.value.split("").reverse().join("") === rdfTerm.value
     return terms.createBoolean(result)
   },
+  // Test if a number is even
   'http://example.com#IS_EVEN': function (rdfTerm) {
-    const result = rdfTerm.value % 2 === 0
-    return terms.createBoolean(result)
+    if (terms.isNumber(rdfTerm)) {
+      const result = rdfTerm.value % 2 === 0
+      return terms.createBoolean(result)
+    }
+    return terms.createBoolean(false)
   }
 }
 ```
 
-This JSON object is then passed into the constructor of your PlanBuilder:
+Then, this JSON object is passed into the constructor of your PlanBuilder.
 
 ```javascript
 const builder = new PlanBuilder(dataset, {}, customFunctions)
 ```
 
-## Use the function in a query
-
-Here's a query using the newly defined custom SPARQL functions:
+Now, you can execute SPARQL queries with your custom functions!
+For example, here is a query that uses our newly defined custom SPARQL functions.
 
 ```
 PREFIX foaf: <http://xmlns.com/foaf/0.1/>
@@ -224,9 +231,14 @@ PREFIX example: <http://example.com#>
 SELECT ?length
 WHERE {
   ?s foaf:name ?name .
-  FILTER (!example:IS_PALINDROME(?name)) .
-  BIND(<http://example.com#REVERSE>(?name) as ?reverse) . # this bind is not critical to this query, but is here for illustrative purposes
+
+  # this bind is not critical, but is here for illustrative purposes
+  BIND(<http://example.com#REVERSE>(?name) as ?reverse)
+
   BIND(STRLEN(?reverse) as ?length)
+
+  # only keeps palindromes
+  FILTER (!example:IS_PALINDROME(?name))
 }
 GROUP BY ?length
 HAVING (example:IS_EVEN(?length))

--- a/README.md
+++ b/README.md
@@ -181,8 +181,6 @@ Finally, to run a SPARQL query on your RDF dataset, you need to use the `PlanBui
 SPARQL allows custom functions in expressions so that queries can be used on domain-specific data.
 The `sparql-engine` framework provides a supports for declaring such custom functions.
 
-## Setp 1: Create a JSON object mapping
-
 A SPARQL value function is an extension point of the SPARQL query language that allows URI to name a function in the query processor.
 It is defined by an `IRI` in a `FILTER`, `BIND` or `HAVING BY` expression.
 To register custom functions, you must create a JSON object that maps each `IRI` to a Javascript function that takes a variable number of [RDFTerms](./src/rdf-terms.ts) arguments and returns an `RDFTerm`.

--- a/README.md
+++ b/README.md
@@ -185,11 +185,11 @@ The `sparql-engine` framework provides a supports for declaring such custom func
 A SPARQL custom functions is defined by an `IRI` (or prefixed name) in `FILTER`, `BIND` or `HAVING BY` expressions.
 You must create a JSON object that maps each `IRI` to a function that takes a variable number of [RDFTerms](./src/rdf-terms.ts) and returns an `RDFTerm`.
 Here is a snipped from the working [example](./examples/custom-functions.js).
-See [the `rdf-terms` documentation](https://github.com/Callidon/sparql-engine/blob/master/src/rdf-terms.ts) for more details on how to manipulate RDF terms.
+See [the `terms` package documentation](https://callidon.github.io/sparql-engine/modules/terms.html) for more details on how to manipulate RDF terms.
 
 ```javascript
 // load the utility functions used to manipulate RDF terms
-const terms = require('sparql-engine/dist/rdf-terms')
+const { terms } = require('sparql-engine')
 
 // define some custom SPARQL functions
 const customFunctions = {

--- a/README.md
+++ b/README.md
@@ -182,10 +182,10 @@ The `sparql-engine` framework provides a supports for declaring such custom func
 
 ## Setp 1: Create a JSON object mapping
 
-A SPARQL custom functions is defined by an `IRI` (or prefixed name) in `FILTER`, `BIND` or `HAVING BY` expressions. 
-You must create a JSON object that maps each `IRI` to a function that takes a variable number of [RDFTerms](./src/rdf-terms.ts) and returns an `RDFTerm`. 
+A SPARQL custom functions is defined by an `IRI` (or prefixed name) in `FILTER`, `BIND` or `HAVING BY` expressions.
+You must create a JSON object that maps each `IRI` to a function that takes a variable number of [RDFTerms](./src/rdf-terms.ts) and returns an `RDFTerm`.
 Here is a snipped from the working [example](./examples/custom-functions.js).
-See [these utility functions](https://github.com/Callidon/sparql-engine/blob/master/src/rdf-terms.ts) for more details on how to manipulate RDF terms.
+See [the `rdf-terms` documentation](https://github.com/Callidon/sparql-engine/blob/master/src/rdf-terms.ts) for more details on how to manipulate RDF terms.
 
 ```javascript
 // load the utility functions used to manipulate RDF terms
@@ -195,20 +195,20 @@ const terms = require('sparql-engine/dist/rdf-terms')
 const customFunctions = {
   'http://example.com#REVERSE': function (rdfTerm) {
     const reverseValue = rdfTerm.value.split("").reverse().join("")
-    return cloneLiteral(rdfTerm, reverseValue)
+    return terms.replaceLiteralValue(rdfTerm, reverseValue)
   },
   'http://example.com#IS_PALINDROME': function (rdfTerm) {
     const result = rdfTerm.value.split("").reverse().join("") === rdfTerm.value
-    return terms.BooleanDescriptor(result)
+    return terms.createBoolean(result)
   },
   'http://example.com#IS_EVEN': function (rdfTerm) {
     const result = rdfTerm.value % 2 === 0
-    return terms.BooleanDescriptor(result)
+    return terms.createBoolean(result)
   }
 }
 ```
 
-This JSON object is then passed into the constructor of your PlanBuilder: 
+This JSON object is then passed into the constructor of your PlanBuilder:
 
 ```javascript
 const builder = new PlanBuilder(dataset, {}, customFunctions)
@@ -223,12 +223,12 @@ PREFIX foaf: <http://xmlns.com/foaf/0.1/>
 PREFIX example: <http://example.com#>
 SELECT ?length
 WHERE {
-  ?s foaf:name ?name . 
+  ?s foaf:name ?name .
   FILTER (!example:IS_PALINDROME(?name)) .
   BIND(<http://example.com#REVERSE>(?name) as ?reverse) . # this bind is not critical to this query, but is here for illustrative purposes
   BIND(STRLEN(?reverse) as ?length)
 }
-GROUP BY ?length 
+GROUP BY ?length
 HAVING (example:IS_EVEN(?length))
 ```
 

--- a/examples/custom-functions.js
+++ b/examples/custom-functions.js
@@ -1,8 +1,7 @@
 'use strict'
 
 const { Parser, Store } = require('n3')
-const { HashMapDataset, Graph, PlanBuilder } = require('../')
-const terms = require('../dist/rdf-terms')
+const { HashMapDataset, Graph, PlanBuilder, terms } = require('../')
 
 // Format a triple pattern according to N3 API:
 // SPARQL variables must be replaced by `null` values

--- a/examples/custom-functions.js
+++ b/examples/custom-functions.js
@@ -85,33 +85,22 @@ const query = `
     BIND(<http://example.com#REVERSE>(?name) as ?reverse) . # this bind is not critical to this query, but is here for illustrative purposes
     BIND(STRLEN(?reverse) as ?length)
   }
-  GROUP BY ?length 
+  GROUP BY ?length
   HAVING (example:IS_EVEN(?length))
   `
-
-function cloneLiteral(base, newValue) {
-  switch (base.type) {
-    case 'literal+type':
-      return terms.TypedLiteralDescriptor(newValue, base.datatype)
-    case 'literal+lang':
-      return terms.LangLiteralDescriptor(newValue, base.lang)
-    default:
-      return terms.RawLiteralDescriptor(newValue)
-  }
-}
 
 const customFunctions = {
   'http://example.com#REVERSE': function (rdfTerm) {
     const reverseValue = rdfTerm.value.split("").reverse().join("")
-    return cloneLiteral(rdfTerm, reverseValue)
+    return terms.replaceLiteralValue(rdfTerm, reverseValue)
   },
   'http://example.com#IS_PALINDROME': function (rdfTerm) {
     const result = rdfTerm.value.split("").reverse().join("") === rdfTerm.value
-    return terms.BooleanDescriptor(result)
+    return terms.createBoolean(result)
   },
   'http://example.com#IS_EVEN': function (rdfTerm) {
     const result = rdfTerm.value % 2 === 0
-    return terms.BooleanDescriptor(result)
+    return terms.createBoolean(result)
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1688,9 +1688,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.10",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
     },
     "loose-envify": {
       "version": "1.4.0",
@@ -1860,7 +1860,6 @@
           "version": "0.1.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -2803,8 +2802,7 @@
         "longest": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "lru-cache": {
           "version": "4.1.3",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "typescript": "^3.0.3"
   },
   "dependencies": {
-    "lodash": "^4.17.10",
+    "lodash": "^4.17.11",
     "moment": "^2.22.2",
     "n3": "^0.11.3",
     "rxjs": "^6.3.3",

--- a/src/api.ts
+++ b/src/api.ts
@@ -35,5 +35,7 @@ export { default as BGPExecutor } from './engine/executors/bgp-executor'
 export { default as GraphExecutor } from './engine/executors/graph-executor'
 export { default as ServiceExecutor } from './engine/executors/service-executor'
 export { default as UpdateExecutor } from './engine/executors/update-executor'
+// RDF terms Utilities
+export { terms } from './rdf-terms' 
 // formatters
 // export { default as XMLFormatter } from './formatters/xml-formatter'

--- a/src/engine/plan-builder.ts
+++ b/src/engine/plan-builder.ts
@@ -30,7 +30,7 @@ import { Observable, of, merge } from 'rxjs'
 import { map, take, skip } from 'rxjs/operators'
 import { Consumable } from '../operators/update/consumer'
 // RDF core classes
-import { IRI, RDFTerm } from '../rdf-terms'
+import { terms } from '../rdf-terms'
 import { Bindings, BindingBase } from '../rdf/bindings'
 import Dataset from '../rdf/dataset'
 // SPARQL query operators
@@ -78,24 +78,9 @@ const QUERY_MODIFIERS = {
 export type QueryOutput = Bindings | Algebra.TripleObject | boolean
 
 /**
- * Type alias to describe the shape of custom functions. It's basically a JSON object from an IRI (in string form) to a function of 0 to many RDFTerms that produces an RDFTerm:
- * const customFunctions = {
- *   'http://example.com#REVERSE': function (a) {
- *     const reverseValue = a.value.split("").reverse().join("")
- *     return cloneLiteral(a, reverseValue)
- *   },
- *   'http://example.com#IS_PALINDROME': function (a) {
- *     const result = a.value.split("").reverse().join("") === a.value
- *     return terms.BooleanDescriptor(result)
- *   },
- *   'http://example.com#IS_EVEN': function (a) {
- *     const result = a.value % 2 === 0
- *     return terms.BooleanDescriptor(result)
- *   }
- * } 
- * 
+ * Type alias to describe the shape of custom functions. It's basically a JSON object from an IRI (in string form) to a function of 0 to many RDFTerms that produces an RDFTerm.
  */
-export type CustomFunctions = { [key:string]: (...args: (RDFTerm | RDFTerm[] | null)[]) => RDFTerm }
+export type CustomFunctions = { [key:string]: (...args: (terms.RDFTerm | terms.RDFTerm[] | null)[]) => terms.RDFTerm }
 
 /**
  * A PlanBuilder builds a physical query execution plan of a SPARQL query,

--- a/src/operators/expressions/sparql-aggregates.ts
+++ b/src/operators/expressions/sparql-aggregates.ts
@@ -25,7 +25,7 @@ SOFTWARE.
 'use strict'
 
 import { rdf } from '../../utils'
-import * as terms from '../../rdf-terms'
+import { terms } from '../../rdf-terms'
 import { maxBy, meanBy, minBy, sample } from 'lodash'
 
 /**

--- a/src/operators/expressions/sparql-aggregates.ts
+++ b/src/operators/expressions/sparql-aggregates.ts
@@ -42,7 +42,7 @@ export default {
     if (variable in rows) {
       count = rows[variable].map((v: string[]) => v !== null).length
     }
-    return terms.NumericOperation(count, rdf.XSD('integer'))
+    return terms.createNumber(count, rdf.XSD('integer'))
   },
 
   'sum': function (variable: string, rows: Object[]): terms.RDFTerm {
@@ -52,7 +52,7 @@ export default {
         return acc + b.asJS
       }, 0)
     }
-    return terms.NumericOperation(sum, rdf.XSD('integer'))
+    return terms.createNumber(sum, rdf.XSD('integer'))
   },
 
   'avg': function (variable: string, rows: Object[]): terms.RDFTerm {
@@ -60,20 +60,20 @@ export default {
     if (variable in rows) {
       avg = meanBy(rows[variable], (v: terms.RDFTerm) => v.asJS)
     }
-    return terms.NumericOperation(avg, rdf.XSD('integer'))
+    return terms.createNumber(avg, rdf.XSD('integer'))
   },
 
   'min': function (variable: string, rows: Object[]): terms.RDFTerm {
-    return minBy(rows[variable], (v: terms.RDFTerm) => v.asJS) || terms.NumericOperation(-1, rdf.XSD('integer'))
+    return minBy(rows[variable], (v: terms.RDFTerm) => v.asJS) || terms.createNumber(-1, rdf.XSD('integer'))
   },
 
   'max': function (variable: string, rows: Object[]): terms.RDFTerm {
-    return maxBy(rows[variable], (v: terms.RDFTerm) => v.asJS) || terms.NumericOperation(-1, rdf.XSD('integer'))
+    return maxBy(rows[variable], (v: terms.RDFTerm) => v.asJS) || terms.createNumber(-1, rdf.XSD('integer'))
   },
 
   'group_concat': function (variable: string, rows: Object[], sep: string): terms.RDFTerm {
     const value = rows[variable].map((v: terms.RDFTerm) => v.value).join(sep)
-    return terms.RawLiteralDescriptor(value)
+    return terms.createLiteral(value)
   },
 
   'sample': function (variable: string, rows: Object[]): terms.RDFTerm {

--- a/src/operators/expressions/sparql-expression.ts
+++ b/src/operators/expressions/sparql-expression.ts
@@ -26,7 +26,7 @@ SOFTWARE.
 
 import SPARQL_AGGREGATES from './sparql-aggregates'
 import SPARQL_OPERATIONS from './sparql-operations'
-import { RDFTerm } from '../../rdf-terms'
+import { terms } from '../../rdf-terms'
 import { rdf } from '../../utils'
 import { isArray, isString } from 'lodash'
 import { Algebra } from 'sparqljs'
@@ -41,9 +41,9 @@ export type InputExpression = Algebra.Expression | string | string[]
 /**
  * A SPARQL expression compiled as a function
  */
-export type CompiledExpression = (bindings: Bindings) => RDFTerm | RDFTerm[] | null
+export type CompiledExpression = (bindings: Bindings) => terms.RDFTerm | terms.RDFTerm[] | null
 
-function bindArgument (variable: string): (bindings: Bindings) => RDFTerm | null {
+function bindArgument (variable: string): (bindings: Bindings) => terms.RDFTerm | null {
   return (bindings: Bindings) => {
     if (bindings.has(variable)) {
       return rdf.parseTerm(bindings.get(variable)!)
@@ -110,9 +110,9 @@ export default class SPARQLExpression {
       }
     } else if (expression.type === 'functionCall') {
       const functionExpression = <Algebra.FunctionCallExpression> expression
-      const customFunction = 
-        (customFunctions && customFunctions[functionExpression.function]) 
-          ? customFunctions[functionExpression.function] 
+      const customFunction =
+        (customFunctions && customFunctions[functionExpression.function])
+          ? customFunctions[functionExpression.function]
           : null
 
       if (!customFunction) {
@@ -139,7 +139,7 @@ export default class SPARQLExpression {
    * @param  bindings - Set of mappings
    * @return Results of the evaluation
    */
-  evaluate (bindings: Bindings): RDFTerm | RDFTerm[] | null {
+  evaluate (bindings: Bindings): terms.RDFTerm | terms.RDFTerm[] | null {
     return this._expression(bindings)
   }
 }

--- a/src/operators/expressions/sparql-operations.ts
+++ b/src/operators/expressions/sparql-operations.ts
@@ -32,50 +32,6 @@ import { isNull } from 'lodash'
 import * as crypto from 'crypto'
 
 /**
- * Test if Two RDF Terms are equal
- * @see https://www.w3.org/TR/sparql11-query/#func-RDFterm-equal
- * @param {Object} a - Left Term
- * @param {Object} b - Right term
- * @return {Object} A RDF Literal with the results of the test
- */
-function RDFTermEqual (a: terms.RDFTerm, b: terms.RDFTerm): terms.RDFTerm {
-  if (a.type !== b.type) {
-    return terms.createBoolean(false)
-  }
-  switch (a.type) {
-    case 'iri':
-    case 'literal':
-      return terms.createBoolean(a.value === b.value)
-    case 'literal+type':
-      return terms.createBoolean(a.value === b.value && (<terms.TypedLiteral> a).datatype === (<terms.TypedLiteral> b).datatype)
-    case 'literal+lang':
-      return terms.createBoolean(a.value === b.value && (<terms.LangLiteral> a).lang === (<terms.LangLiteral> b).lang)
-    default:
-      return terms.createBoolean(false)
-  }
-}
-
-/**
- * Return True if a literal is a Date
- * @param  {Object}  literal - Literal to analyze
- * @return {Boolean} True if a literal is a Date, False otherwise
- */
-function isDate (literal: terms.RDFTerm): boolean {
-    return literal.type === 'literal+type' && (<terms.TypedLiteral> literal).datatype === rdf.XSD('dateTime')
-}
-
-function cloneLiteral (base: terms.RDFTerm, newValue: string): terms.RDFTerm {
-  switch (base.type) {
-    case 'literal+type':
-      return terms.createTypedLiteral(newValue, (<terms.TypedLiteral> base).datatype)
-    case 'literal+lang':
-      return terms.createLangLiteral(newValue, (<terms.LangLiteral> base).lang)
-    default:
-      return terms.createLiteral(newValue)
-  }
-}
-
-/**
  * Return a high-orderpply a Hash function  to a RDF
  * and returns the corresponding RDF Literal
  * @param  {string} hashType - Type of hash (md5, sha256, etc)
@@ -103,7 +59,7 @@ export default {
     XQuery & XPath functions https://www.w3.org/TR/sparql11-query/#OperatorMapping
   */
   '+': function (a: terms.RDFTerm, b: terms.RDFTerm): terms.RDFTerm {
-    if (isDate(a) || isDate(b)) {
+    if (terms.isDate(a) || terms.isDate(b)) {
       return terms.createDate(a.asJS + b.asJS)
     } else if (a.type === 'literal+type' && b.type === 'literal+type') {
       return terms.createNumber(a.asJS + b.asJS, (<terms.TypedLiteral> a).datatype)
@@ -112,7 +68,7 @@ export default {
   },
 
   '-': function (a: terms.RDFTerm, b: terms.RDFTerm): terms.RDFTerm {
-    if (isDate(a) || isDate(b)) {
+    if (terms.isDate(a) || terms.isDate(b)) {
       return terms.createDate(moment(a.asJS - b.asJS))
     } else if (a.type === 'literal+type' && b.type === 'literal+type') {
       return terms.createNumber(a.asJS - b.asJS, (<terms.TypedLiteral> a).datatype)
@@ -121,7 +77,7 @@ export default {
   },
 
   '*': function (a: terms.RDFTerm, b: terms.RDFTerm): terms.RDFTerm {
-    if (isDate(a) || isDate(b)) {
+    if (terms.isDate(a) || terms.isDate(b)) {
       return terms.createDate(moment(a.asJS * b.asJS))
     } else if (a.type === 'literal+type' && b.type === 'literal+type') {
       return terms.createNumber(a.asJS * b.asJS, (<terms.TypedLiteral> a).datatype)
@@ -130,7 +86,7 @@ export default {
   },
 
   '/': function (a: terms.RDFTerm, b: terms.RDFTerm): terms.RDFTerm {
-    if (isDate(a) || isDate(b)) {
+    if (terms.isDate(a) || terms.isDate(b)) {
       return terms.createDate(moment(a.asJS / b.asJS))
     } else if (a.type === 'literal+type' && b.type === 'literal+type') {
       return terms.createNumber(a.asJS / b.asJS, (<terms.TypedLiteral> a).datatype)
@@ -139,42 +95,42 @@ export default {
   },
 
   '=': function (a: terms.RDFTerm, b: terms.RDFTerm): terms.RDFTerm {
-    if (isDate(a) && isDate(b)) {
+    if (terms.isDate(a) && terms.isDate(b)) {
       return terms.createBoolean(a.asJS.isSame(b.asJS))
     }
-    return RDFTermEqual(a, b)
+    return terms.equals(a, b)
   },
 
   '!=': function (a: terms.RDFTerm, b: terms.RDFTerm): terms.RDFTerm {
-    if (isDate(a) && isDate(b)) {
+    if (terms.isDate(a) && terms.isDate(b)) {
       return terms.createBoolean(!(a.asJS.isSame(b.asJS)))
     }
     return terms.createBoolean(a.asJS !== b.asJS)
   },
 
   '<': function (a: terms.RDFTerm, b: terms.RDFTerm): terms.RDFTerm {
-    if (isDate(a) && isDate(b)) {
+    if (terms.isDate(a) && terms.isDate(b)) {
       return terms.createBoolean(a.asJS.isBefore(b.asJS))
     }
     return terms.createBoolean(a.asJS < b.asJS)
   },
 
   '<=': function (a: terms.RDFTerm, b: terms.RDFTerm): terms.RDFTerm {
-    if (isDate(a) && isDate(b)) {
+    if (terms.isDate(a) && terms.isDate(b)) {
       return terms.createBoolean(a.asJS.isSameOrBefore(b.asJS))
     }
     return terms.createBoolean(a.asJS <= b.asJS)
   },
 
   '>': function (a: terms.RDFTerm, b: terms.RDFTerm): terms.RDFTerm {
-    if (isDate(a) && isDate(b)) {
+    if (terms.isDate(a) && terms.isDate(b)) {
       return terms.createBoolean(a.asJS.isAfter(b.asJS))
     }
     return terms.createBoolean(a.asJS > b.asJS)
   },
 
   '>=': function (a: terms.RDFTerm, b: terms.RDFTerm): terms.RDFTerm {
-    if (isDate(a) && isDate(b)) {
+    if (terms.isDate(a) && terms.isDate(b)) {
       return terms.createBoolean(a.asJS.isSameOrAfter(b.asJS))
     }
     return terms.createBoolean(a.asJS >= b.asJS)
@@ -200,7 +156,7 @@ export default {
   },
 
   'sameterm': function (a: terms.RDFTerm, b: terms.RDFTerm): terms.RDFTerm {
-    return RDFTermEqual(a, b)
+    return terms.equals(a, b)
   },
 
   'in': function (a: terms.RDFTerm, b: terms.RDFTerm[]): terms.RDFTerm {
@@ -291,15 +247,15 @@ export default {
     if (length !== null && length !== undefined) {
       value = value.substring(0, length.asJS)
     }
-    return cloneLiteral(str, value)
+    return terms.replaceLiteralValue(str, value)
   },
 
   'ucase': function (a: terms.RDFTerm): terms.RDFTerm {
-    return cloneLiteral(a, a.value.toUpperCase())
+    return terms.replaceLiteralValue(a, a.value.toUpperCase())
   },
 
   'lcase': function (a: terms.RDFTerm): terms.RDFTerm {
-    return cloneLiteral(a, a.value.toLowerCase())
+    return terms.replaceLiteralValue(a, a.value.toLowerCase())
   },
 
   'strstarts': function (string: terms.RDFTerm, substring: terms.RDFTerm): terms.RDFTerm {
@@ -323,13 +279,13 @@ export default {
   'strbefore': function (str: terms.RDFTerm, token: terms.RDFTerm): terms.RDFTerm {
     const index = str.value.indexOf(token.value)
     const value = (index > -1) ? str.value.substring(0, index) : ''
-    return cloneLiteral(str, value)
+    return terms.replaceLiteralValue(str, value)
   },
 
   'strafter': function (str: terms.RDFTerm, token: terms.RDFTerm): terms.RDFTerm {
     const index = str.value.indexOf(token.value)
     const value = (index > -1) ? str.value.substring(index + token.value.length) : ''
-    return cloneLiteral(str, value)
+    return terms.replaceLiteralValue(str, value)
   },
 
   'encode_for_uri': function (a: terms.RDFTerm): terms.RDFTerm {
@@ -340,7 +296,7 @@ export default {
     if (a.type !== b.type) {
       return terms.createLiteral(a.value + b.value)
     }
-    return cloneLiteral(a, a.value + b.value)
+    return terms.replaceLiteralValue(a, a.value + b.value)
   },
 
   'langmatches': function (langTag: terms.RDFTerm, langRange: terms.RDFTerm): terms.RDFTerm {

--- a/src/operators/expressions/sparql-operations.ts
+++ b/src/operators/expressions/sparql-operations.ts
@@ -25,7 +25,7 @@ SOFTWARE.
 'use strict'
 
 import { rdf } from '../../utils'
-import * as terms from '../../rdf-terms'
+import { terms } from '../../rdf-terms'
 import * as moment from 'moment'
 import * as uuid from 'uuid/v4'
 import { isNull } from 'lodash'

--- a/src/operators/expressions/sparql-operations.ts
+++ b/src/operators/expressions/sparql-operations.ts
@@ -40,18 +40,18 @@ import * as crypto from 'crypto'
  */
 function RDFTermEqual (a: terms.RDFTerm, b: terms.RDFTerm): terms.RDFTerm {
   if (a.type !== b.type) {
-    return terms.BooleanDescriptor(false)
+    return terms.createBoolean(false)
   }
   switch (a.type) {
     case 'iri':
     case 'literal':
-      return terms.BooleanDescriptor(a.value === b.value)
+      return terms.createBoolean(a.value === b.value)
     case 'literal+type':
-      return terms.BooleanDescriptor(a.value === b.value && (<terms.TypedLiteral> a).datatype === (<terms.TypedLiteral> b).datatype)
+      return terms.createBoolean(a.value === b.value && (<terms.TypedLiteral> a).datatype === (<terms.TypedLiteral> b).datatype)
     case 'literal+lang':
-      return terms.BooleanDescriptor(a.value === b.value && (<terms.LangLiteral> a).lang === (<terms.LangLiteral> b).lang)
+      return terms.createBoolean(a.value === b.value && (<terms.LangLiteral> a).lang === (<terms.LangLiteral> b).lang)
     default:
-      return terms.BooleanDescriptor(false)
+      return terms.createBoolean(false)
   }
 }
 
@@ -67,11 +67,11 @@ function isDate (literal: terms.RDFTerm): boolean {
 function cloneLiteral (base: terms.RDFTerm, newValue: string): terms.RDFTerm {
   switch (base.type) {
     case 'literal+type':
-      return terms.TypedLiteralDescriptor(newValue, (<terms.TypedLiteral> base).datatype)
+      return terms.createTypedLiteral(newValue, (<terms.TypedLiteral> base).datatype)
     case 'literal+lang':
-      return terms.LangLiteralDescriptor(newValue, (<terms.LangLiteral> base).lang)
+      return terms.createLangLiteral(newValue, (<terms.LangLiteral> base).lang)
     default:
-      return terms.RawLiteralDescriptor(newValue)
+      return terms.createLiteral(newValue)
   }
 }
 
@@ -85,7 +85,7 @@ function applyHash (hashType: string): (v: terms.RDFTerm) => terms.RDFTerm {
   return v => {
     const hash = crypto.createHash(hashType)
     hash.update(v.value)
-    return terms.RawLiteralDescriptor(hash.digest('hex'))
+    return terms.createLiteral(hash.digest('hex'))
   }
 }
 
@@ -104,99 +104,99 @@ export default {
   */
   '+': function (a: terms.RDFTerm, b: terms.RDFTerm): terms.RDFTerm {
     if (isDate(a) || isDate(b)) {
-      return terms.DateLiteral(a.asJS + b.asJS)
+      return terms.createDate(a.asJS + b.asJS)
     } else if (a.type === 'literal+type' && b.type === 'literal+type') {
-      return terms.NumericOperation(a.asJS + b.asJS, (<terms.TypedLiteral> a).datatype)
+      return terms.createNumber(a.asJS + b.asJS, (<terms.TypedLiteral> a).datatype)
     }
-    return terms.RawLiteralDescriptor(a.asJS + b.asJS)
+    return terms.createLiteral(a.asJS + b.asJS)
   },
 
   '-': function (a: terms.RDFTerm, b: terms.RDFTerm): terms.RDFTerm {
     if (isDate(a) || isDate(b)) {
-      return terms.DateLiteral(moment(a.asJS - b.asJS))
+      return terms.createDate(moment(a.asJS - b.asJS))
     } else if (a.type === 'literal+type' && b.type === 'literal+type') {
-      return terms.NumericOperation(a.asJS - b.asJS, (<terms.TypedLiteral> a).datatype)
+      return terms.createNumber(a.asJS - b.asJS, (<terms.TypedLiteral> a).datatype)
     }
-    return terms.RawLiteralDescriptor('')
+    return terms.createLiteral('')
   },
 
   '*': function (a: terms.RDFTerm, b: terms.RDFTerm): terms.RDFTerm {
     if (isDate(a) || isDate(b)) {
-      return terms.DateLiteral(moment(a.asJS * b.asJS))
+      return terms.createDate(moment(a.asJS * b.asJS))
     } else if (a.type === 'literal+type' && b.type === 'literal+type') {
-      return terms.NumericOperation(a.asJS * b.asJS, (<terms.TypedLiteral> a).datatype)
+      return terms.createNumber(a.asJS * b.asJS, (<terms.TypedLiteral> a).datatype)
     }
-    return terms.RawLiteralDescriptor('')
+    return terms.createLiteral('')
   },
 
   '/': function (a: terms.RDFTerm, b: terms.RDFTerm): terms.RDFTerm {
     if (isDate(a) || isDate(b)) {
-      return terms.DateLiteral(moment(a.asJS / b.asJS))
+      return terms.createDate(moment(a.asJS / b.asJS))
     } else if (a.type === 'literal+type' && b.type === 'literal+type') {
-      return terms.NumericOperation(a.asJS / b.asJS, (<terms.TypedLiteral> a).datatype)
+      return terms.createNumber(a.asJS / b.asJS, (<terms.TypedLiteral> a).datatype)
     }
-    return terms.RawLiteralDescriptor('')
+    return terms.createLiteral('')
   },
 
   '=': function (a: terms.RDFTerm, b: terms.RDFTerm): terms.RDFTerm {
     if (isDate(a) && isDate(b)) {
-      return terms.BooleanDescriptor(a.asJS.isSame(b.asJS))
+      return terms.createBoolean(a.asJS.isSame(b.asJS))
     }
     return RDFTermEqual(a, b)
   },
 
   '!=': function (a: terms.RDFTerm, b: terms.RDFTerm): terms.RDFTerm {
     if (isDate(a) && isDate(b)) {
-      return terms.BooleanDescriptor(!(a.asJS.isSame(b.asJS)))
+      return terms.createBoolean(!(a.asJS.isSame(b.asJS)))
     }
-    return terms.BooleanDescriptor(a.asJS !== b.asJS)
+    return terms.createBoolean(a.asJS !== b.asJS)
   },
 
   '<': function (a: terms.RDFTerm, b: terms.RDFTerm): terms.RDFTerm {
     if (isDate(a) && isDate(b)) {
-      return terms.BooleanDescriptor(a.asJS.isBefore(b.asJS))
+      return terms.createBoolean(a.asJS.isBefore(b.asJS))
     }
-    return terms.BooleanDescriptor(a.asJS < b.asJS)
+    return terms.createBoolean(a.asJS < b.asJS)
   },
 
   '<=': function (a: terms.RDFTerm, b: terms.RDFTerm): terms.RDFTerm {
     if (isDate(a) && isDate(b)) {
-      return terms.BooleanDescriptor(a.asJS.isSameOrBefore(b.asJS))
+      return terms.createBoolean(a.asJS.isSameOrBefore(b.asJS))
     }
-    return terms.BooleanDescriptor(a.asJS <= b.asJS)
+    return terms.createBoolean(a.asJS <= b.asJS)
   },
 
   '>': function (a: terms.RDFTerm, b: terms.RDFTerm): terms.RDFTerm {
     if (isDate(a) && isDate(b)) {
-      return terms.BooleanDescriptor(a.asJS.isAfter(b.asJS))
+      return terms.createBoolean(a.asJS.isAfter(b.asJS))
     }
-    return terms.BooleanDescriptor(a.asJS > b.asJS)
+    return terms.createBoolean(a.asJS > b.asJS)
   },
 
   '>=': function (a: terms.RDFTerm, b: terms.RDFTerm): terms.RDFTerm {
     if (isDate(a) && isDate(b)) {
-      return terms.BooleanDescriptor(a.asJS.isSameOrAfter(b.asJS))
+      return terms.createBoolean(a.asJS.isSameOrAfter(b.asJS))
     }
-    return terms.BooleanDescriptor(a.asJS >= b.asJS)
+    return terms.createBoolean(a.asJS >= b.asJS)
   },
 
   '!': function (a: terms.RDFTerm): terms.RDFTerm {
-    return terms.BooleanDescriptor(!a.asJS)
+    return terms.createBoolean(!a.asJS)
   },
 
   '&&': function (a: terms.RDFTerm, b: terms.RDFTerm): terms.RDFTerm {
-    return terms.BooleanDescriptor(a.asJS && b.asJS)
+    return terms.createBoolean(a.asJS && b.asJS)
   },
 
   '||': function (a: terms.RDFTerm, b: terms.RDFTerm): terms.RDFTerm {
-    return terms.BooleanDescriptor(a.asJS || b.asJS)
+    return terms.createBoolean(a.asJS || b.asJS)
   },
 
   /*
     SPARQL Functional forms https://www.w3.org/TR/sparql11-query/#func-forms
   */
   'bound': function (a: terms.RDFTerm) {
-    return terms.BooleanDescriptor(!isNull(a))
+    return terms.createBoolean(!isNull(a))
   },
 
   'sameterm': function (a: terms.RDFTerm, b: terms.RDFTerm): terms.RDFTerm {
@@ -204,11 +204,11 @@ export default {
   },
 
   'in': function (a: terms.RDFTerm, b: terms.RDFTerm[]): terms.RDFTerm {
-    return terms.BooleanDescriptor(b.some(elt => a.asJS === elt.asJS))
+    return terms.createBoolean(b.some(elt => a.asJS === elt.asJS))
   },
 
   'notin': function (a: terms.RDFTerm, b: terms.RDFTerm[]): terms.RDFTerm {
-    return terms.BooleanDescriptor(!b.some(elt => a.asJS === elt.asJS))
+    return terms.createBoolean(!b.some(elt => a.asJS === elt.asJS))
   },
 
   /*
@@ -216,63 +216,63 @@ export default {
   */
 
   'isiri': function (a: terms.RDFTerm): terms.RDFTerm {
-    return terms.BooleanDescriptor(a.type === 'iri')
+    return terms.createBoolean(a.type === 'iri')
   },
 
   'isblank': function (a: terms.RDFTerm): terms.RDFTerm {
-    return terms.BooleanDescriptor(a.type === 'bnode')
+    return terms.createBoolean(a.type === 'bnode')
   },
 
   'isliteral': function (a: terms.RDFTerm): terms.RDFTerm {
-    return terms.BooleanDescriptor(a.type.startsWith('literal'))
+    return terms.createBoolean(a.type.startsWith('literal'))
   },
 
   'isnumeric': function (a: terms.RDFTerm): terms.RDFTerm {
-    return terms.BooleanDescriptor(!isNaN(a.asJS))
+    return terms.createBoolean(!isNaN(a.asJS))
   },
 
   'str': function (a: terms.RDFTerm): terms.RDFTerm {
-    return a.type.startsWith('literal') ? a : terms.RawLiteralDescriptor(a.value)
+    return a.type.startsWith('literal') ? a : terms.createLiteral(a.value)
   },
 
   'lang': function (a: terms.RDFTerm): terms.RDFTerm {
     if (a.type === 'literal+lang') {
-      return terms.RawLiteralDescriptor((<terms.LangLiteral> a).lang.toLowerCase())
+      return terms.createLiteral((<terms.LangLiteral> a).lang.toLowerCase())
     }
-    return terms.RawLiteralDescriptor('')
+    return terms.createLiteral('')
   },
 
   'datatype': function (a: terms.RDFTerm): terms.RDFTerm {
     switch (a.type) {
       case 'literal':
-        return terms.IRIDescriptor(rdf.XSD('string'))
+        return terms.createIRI(rdf.XSD('string'))
       case 'literal+type':
-        return terms.IRIDescriptor((<terms.TypedLiteral> a).datatype)
+        return terms.createIRI((<terms.TypedLiteral> a).datatype)
       case 'literal+lang':
-        return terms.IRIDescriptor(rdf.RDF('langString'))
+        return terms.createIRI(rdf.RDF('langString'))
       default:
-        return terms.RawLiteralDescriptor('')
+        return terms.createLiteral('')
     }
   },
 
   'iri': function (a: terms.RDFTerm): terms.RDFTerm {
-    return terms.IRIDescriptor(a.value)
+    return terms.createIRI(a.value)
   },
 
   'strdt': function (x: terms.RDFTerm, datatype: terms.RDFTerm): terms.RDFTerm {
-    return terms.TypedLiteralDescriptor(x.value, datatype.value)
+    return terms.createTypedLiteral(x.value, datatype.value)
   },
 
   'strlang': function (x: terms.RDFTerm, lang: terms.RDFTerm): terms.RDFTerm {
-    return terms.LangLiteralDescriptor(x.value, lang.value)
+    return terms.createLangLiteral(x.value, lang.value)
   },
 
   'uuid': function (): terms.RDFTerm {
-    return terms.IRIDescriptor(`urn:uuid:${uuid()}`)
+    return terms.createIRI(`urn:uuid:${uuid()}`)
   },
 
   'struuid': function (): terms.RDFTerm {
-    return terms.RawLiteralDescriptor(uuid())
+    return terms.createLiteral(uuid())
   },
 
   /*
@@ -280,7 +280,7 @@ export default {
   */
 
   'strlen': function (a: terms.RDFTerm): terms.RDFTerm {
-    return terms.NumericOperation(a.value.length, rdf.XSD('integer'))
+    return terms.createNumber(a.value.length, rdf.XSD('integer'))
   },
 
   'substr': function (str: terms.RDFTerm, index: terms.RDFTerm, length?: terms.RDFTerm): terms.RDFTerm {
@@ -305,19 +305,19 @@ export default {
   'strstarts': function (string: terms.RDFTerm, substring: terms.RDFTerm): terms.RDFTerm {
     const a = string.value
     const b = substring.value
-    return terms.BooleanDescriptor(a.startsWith(b))
+    return terms.createBoolean(a.startsWith(b))
   },
 
   'strends': function (string: terms.RDFTerm, substring: terms.RDFTerm): terms.RDFTerm {
     const a = string.value
     const b = substring.value
-    return terms.BooleanDescriptor(a.endsWith(b))
+    return terms.createBoolean(a.endsWith(b))
   },
 
   'contains': function (string: terms.RDFTerm, substring: terms.RDFTerm): terms.RDFTerm {
     const a = string.value
     const b = substring.value
-    return terms.BooleanDescriptor(a.indexOf(b) >= 0)
+    return terms.createBoolean(a.indexOf(b) >= 0)
   },
 
   'strbefore': function (str: terms.RDFTerm, token: terms.RDFTerm): terms.RDFTerm {
@@ -333,12 +333,12 @@ export default {
   },
 
   'encode_for_uri': function (a: terms.RDFTerm): terms.RDFTerm {
-    return terms.RawLiteralDescriptor(encodeURIComponent(a.value))
+    return terms.createLiteral(encodeURIComponent(a.value))
   },
 
   'concat': function (a: terms.RDFTerm, b: terms.RDFTerm): terms.RDFTerm {
     if (a.type !== b.type) {
-      return terms.RawLiteralDescriptor(a.value + b.value)
+      return terms.createLiteral(a.value + b.value)
     }
     return cloneLiteral(a, a.value + b.value)
   },
@@ -350,12 +350,12 @@ export default {
     const test = tag === range ||
                   range === '*' ||
                   tag.substr(1, range.length + 1) === range + '-'
-    return terms.BooleanDescriptor(test)
+    return terms.createBoolean(test)
   },
 
   'regex': function (subject: terms.RDFTerm, pattern: terms.RDFTerm, flags: terms.RDFTerm) {
     let regexp = (flags === null || flags === undefined) ? new RegExp(pattern.value) : new RegExp(pattern.value, flags.value)
-    return terms.BooleanDescriptor(regexp.test(subject.value))
+    return terms.createBoolean(regexp.test(subject.value))
   },
 
   /*
@@ -363,19 +363,19 @@ export default {
   */
 
   'abs': function (a: terms.RDFTerm): terms.RDFTerm {
-    return terms.NumericOperation(Math.abs(a.asJS), rdf.XSD('integer'))
+    return terms.createNumber(Math.abs(a.asJS), rdf.XSD('integer'))
   },
 
   'round': function (a: terms.RDFTerm): terms.RDFTerm {
-    return terms.NumericOperation(Math.round(a.asJS), rdf.XSD('integer'))
+    return terms.createNumber(Math.round(a.asJS), rdf.XSD('integer'))
   },
 
   'ceil': function (a: terms.RDFTerm): terms.RDFTerm {
-    return terms.NumericOperation(Math.ceil(a.asJS), rdf.XSD('integer'))
+    return terms.createNumber(Math.ceil(a.asJS), rdf.XSD('integer'))
   },
 
   'floor': function (a: terms.RDFTerm): terms.RDFTerm {
-    return terms.NumericOperation(Math.floor(a.asJS), rdf.XSD('integer'))
+    return terms.createNumber(Math.floor(a.asJS), rdf.XSD('integer'))
   },
 
   /*
@@ -383,36 +383,36 @@ export default {
   */
 
   'now': function (): terms.RDFTerm {
-    return terms.DateLiteral(moment())
+    return terms.createDate(moment())
   },
 
   'year': function (a: terms.RDFTerm): terms.RDFTerm {
-    return terms.NumericOperation(a.asJS.year(), rdf.XSD('integer'))
+    return terms.createNumber(a.asJS.year(), rdf.XSD('integer'))
   },
 
   'month': function (a: terms.RDFTerm): terms.RDFTerm {
-    return terms.NumericOperation(a.asJS.month() + 1, rdf.XSD('integer'))
+    return terms.createNumber(a.asJS.month() + 1, rdf.XSD('integer'))
   },
 
   'day': function (a: terms.RDFTerm): terms.RDFTerm {
-    return terms.NumericOperation(a.asJS.date(), rdf.XSD('integer'))
+    return terms.createNumber(a.asJS.date(), rdf.XSD('integer'))
   },
 
   'hours': function (a: terms.RDFTerm): terms.RDFTerm {
-    return terms.NumericOperation(a.asJS.hours(), rdf.XSD('integer'))
+    return terms.createNumber(a.asJS.hours(), rdf.XSD('integer'))
   },
 
   'minutes': function (a: terms.RDFTerm): terms.RDFTerm {
-    return terms.NumericOperation(a.asJS.minutes(), rdf.XSD('integer'))
+    return terms.createNumber(a.asJS.minutes(), rdf.XSD('integer'))
   },
 
   'seconds': function (a: terms.RDFTerm): terms.RDFTerm {
-    return terms.NumericOperation(a.asJS.seconds(), rdf.XSD('integer'))
+    return terms.createNumber(a.asJS.seconds(), rdf.XSD('integer'))
   },
 
   'tz': function (a: terms.RDFTerm): terms.RDFTerm {
     const offset = a.asJS.utcOffset() / 60
-    return terms.RawLiteralDescriptor(offset.toString())
+    return terms.createLiteral(offset.toString())
   },
 
   /*

--- a/src/rdf-terms.ts
+++ b/src/rdf-terms.ts
@@ -28,58 +28,6 @@ import { parseZone, Moment } from 'moment'
 import { rdf } from './utils'
 
 /**
- * An intermediate format to represent RDF Terms
- */
-export interface RDFTerm {
-  /**
-   * Type of the term
-   */
-  readonly type: string,
-  /**
-   * Value of the term, in string format
-   */
-  readonly value: string,
-  /**
-   * RDF representation of the term
-   */
-  readonly asRDF: string,
-  /**
-   * JS representation of the term
-   */
-  readonly asJS: any
-}
-
-/**
- * An intermediate format to represent RDF IRIs
- */
-export interface IRI extends RDFTerm {}
-
-/**
- * An intermediate format to represent RDF plain Literals
- */
-export interface RawLiteral extends RDFTerm {}
-
-/**
- * An intermediate format to represent RDF Literal with a language tag
- */
-export interface LangLiteral extends RDFTerm {
-  /**
-   * Language tag
-   */
-  readonly lang: string
-}
-
-/**
- * An intermediate format to represent RDF Literal with a datatype
- */
-export interface TypedLiteral extends RDFTerm {
-  /**
-   * Datatype
-   */
-  readonly datatype: string
-}
-
-/**
  * Parse a RDF Literal to its Javascript representation
  * See https://www.w3.org/TR/rdf11-concepts/#section-Datatypes for more details.
  * @param value - Literal value
@@ -124,160 +72,219 @@ function literalToJS (value: string, type: string): any {
 }
 
 /**
- * Creates an IRI in {@link RDFTerm} format
- * @param iri - IRI
- * @return A new IRI in {@link RDFTerm} format
+ * Utilities used to manipulate RDF terms
+ * @param  iri [description]
+ * @return     [description]
  */
-export function createIRI (iri: string): IRI {
-  return {
-    type: 'iri',
-    value: iri,
-    asRDF: iri,
-    asJS: iri
+export namespace terms {
+  /**
+   * An intermediate format to represent RDF Terms
+   */
+  export interface RDFTerm {
+    /**
+     * Type of the term
+     */
+    readonly type: string,
+    /**
+     * Value of the term, in string format
+     */
+    readonly value: string,
+    /**
+     * RDF representation of the term
+     */
+    readonly asRDF: string,
+    /**
+     * JS representation of the term
+     */
+    readonly asJS: any
   }
-}
 
-/**
- * Creates a Literal in {@link RDFTerm} format
- * @param literal - Literal
- * @return A new Literal in {@link RDFTerm} format
- */
-export function createLiteral (literal: string): RawLiteral {
-  const rdf = `"${literal}"`
-  return {
-    type: 'literal',
-    value: literal,
-    asRDF: rdf,
-    asJS: rdf
-  }
-}
+  /**
+   * An intermediate format to represent RDF IRIs
+   */
+  export interface IRI extends RDFTerm {}
 
-/**
- * Creates a Literal with a datatype, in {@link RDFTerm} format
- * @param literal - Literal
- * @param type - Literal datatype
- * @return A new typed Literal in {@link RDFTerm} format
- */
-export function createTypedLiteral (literal: string, type: string): TypedLiteral {
-  return {
-    type: 'literal+type',
-    value: literal,
-    datatype: type,
-    asRDF: `"${literal}"^^${type}`,
-    asJS: literalToJS(literal, type)
-  }
-}
+  /**
+   * An intermediate format to represent RDF plain Literals
+   */
+  export interface RawLiteral extends RDFTerm {}
 
-/**
- * Creates a Literal with a language tag, in {@link RDFTerm} format
- * @param literal - Literal
- * @param lang - Language tag
- * @return A new tagged Literal in {@link RDFTerm} format
- */
-export function createLangLiteral (literal: string, lang: string): LangLiteral {
-  const rdf = `"${literal}"@${lang}`
-  return {
-    type: 'literal+lang',
-    value: literal,
-    lang,
-    asRDF: rdf,
-    asJS: rdf
+  /**
+   * An intermediate format to represent RDF Literal with a language tag
+   */
+  export interface LangLiteral extends RDFTerm {
+    /**
+     * Language tag
+     */
+    readonly lang: string
   }
-}
 
-/**
- * Creates a Literal from a boolean, in {@link RDFTerm} format
- * @param value - Boolean
- * @return A new typed Literal in {@link RDFTerm} format
- */
-export function createBoolean (value: boolean): TypedLiteral {
-  return {
-    type: 'literal+type',
-    value: `"${value}"`,
-    datatype: 'http://www.w3.org/2001/XMLSchema#boolean',
-    asRDF: `"${value}"^^http://www.w3.org/2001/XMLSchema#boolean`,
-    asJS: value
+  /**
+   * An intermediate format to represent RDF Literal with a datatype
+   */
+  export interface TypedLiteral extends RDFTerm {
+    /**
+     * Datatype
+     */
+    readonly datatype: string
   }
-}
 
-/**
- * Creates a Literal from a number, in {@link RDFTerm} format
- * @param value - Number
- * @param type - Literal type
- * @return A new typed Literal in {@link RDFTerm} format
- */
-export function createNumber (value: number, type: string): TypedLiteral {
-  return {
-    type: 'literal+type',
-    value: value.toString(),
-    datatype: type,
-    asRDF: `"${value}"^^${type}`,
-    asJS: value
+  /**
+   * Creates an IRI in {@link RDFTerm} format
+   * @param iri - IRI
+   * @return A new IRI in {@link RDFTerm} format
+   */
+  export function createIRI (iri: string): IRI {
+    return {
+      type: 'iri',
+      value: iri,
+      asRDF: iri,
+      asJS: iri
+    }
   }
-}
 
-/**
- * Creates a Literal from a Moment date, in {@link RDFTerm} format
- * @param date - A Date, in Moment format
- * @return A new typed Literal in {@link RDFTerm} format
- */
-export function createDate (date: Moment): TypedLiteral {
-  const value = date.toISOString()
-  return {
-    type: 'literal+type',
-    value: value,
-    datatype: 'http://www.w3.org/2001/XMLSchema#dateTime',
-    asRDF: `"${value}"^^http://www.w3.org/2001/XMLSchema#dateTime`,
-    asJS: date
+  /**
+   * Creates a Literal in {@link RDFTerm} format
+   * @param literal - Literal
+   * @return A new Literal in {@link RDFTerm} format
+   */
+  export function createLiteral (literal: string): RawLiteral {
+    const rdf = `"${literal}"`
+    return {
+      type: 'literal',
+      value: literal,
+      asRDF: rdf,
+      asJS: rdf
+    }
   }
-}
 
-/**
- * Clone a literal and replace its value with another one
- * @param  base     - Literal to clone
- * @param  newValue - New literal value
- * @return The literal with its new value
- */
-export function replaceLiteralValue (term: RDFTerm, newValue: string): RDFTerm {
-  switch (term.type) {
-    case 'literal+type':
-      return createTypedLiteral(newValue, (<TypedLiteral> term).datatype)
-    case 'literal+lang':
-      return createLangLiteral(newValue, (<LangLiteral> term).lang)
-    default:
-      return createLiteral(newValue)
+  /**
+   * Creates a Literal with a datatype, in {@link RDFTerm} format
+   * @param literal - Literal
+   * @param type - Literal datatype
+   * @return A new typed Literal in {@link RDFTerm} format
+   */
+  export function createTypedLiteral (literal: string, type: string): TypedLiteral {
+    return {
+      type: 'literal+type',
+      value: literal,
+      datatype: type,
+      asRDF: `"${literal}"^^${type}`,
+      asJS: literalToJS(literal, type)
+    }
   }
-}
 
-/**
- * Test if Two RDF Terms are equals
- * @see https://www.w3.org/TR/sparql11-query/#func-RDFterm-equal
- * @param {Object} a - Left Term
- * @param {Object} b - Right term
- * @return {Object} A RDF Literal with the results of the test
- */
-export function equals (a: RDFTerm, b: RDFTerm): RDFTerm {
-  if (a.type !== b.type) {
-    return createBoolean(false)
+  /**
+   * Creates a Literal with a language tag, in {@link RDFTerm} format
+   * @param literal - Literal
+   * @param lang - Language tag
+   * @return A new tagged Literal in {@link RDFTerm} format
+   */
+  export function createLangLiteral (literal: string, lang: string): LangLiteral {
+    const rdf = `"${literal}"@${lang}`
+    return {
+      type: 'literal+lang',
+      value: literal,
+      lang,
+      asRDF: rdf,
+      asJS: rdf
+    }
   }
-  switch (a.type) {
-    case 'iri':
-    case 'literal':
-      return createBoolean(a.value === b.value)
-    case 'literal+type':
-      return createBoolean(a.value === b.value && (<TypedLiteral> a).datatype === (<TypedLiteral> b).datatype)
-    case 'literal+lang':
-      return createBoolean(a.value === b.value && (<LangLiteral> a).lang === (<LangLiteral> b).lang)
-    default:
+
+  /**
+   * Creates a Literal from a boolean, in {@link RDFTerm} format
+   * @param value - Boolean
+   * @return A new typed Literal in {@link RDFTerm} format
+   */
+  export function createBoolean (value: boolean): TypedLiteral {
+    return {
+      type: 'literal+type',
+      value: `"${value}"`,
+      datatype: 'http://www.w3.org/2001/XMLSchema#boolean',
+      asRDF: `"${value}"^^http://www.w3.org/2001/XMLSchema#boolean`,
+      asJS: value
+    }
+  }
+
+  /**
+   * Creates a Literal from a number, in {@link RDFTerm} format
+   * @param value - Number
+   * @param type - Literal type
+   * @return A new typed Literal in {@link RDFTerm} format
+   */
+  export function createNumber (value: number, type: string): TypedLiteral {
+    return {
+      type: 'literal+type',
+      value: value.toString(),
+      datatype: type,
+      asRDF: `"${value}"^^${type}`,
+      asJS: value
+    }
+  }
+
+  /**
+   * Creates a Literal from a Moment date, in {@link RDFTerm} format
+   * @param date - A Date, in Moment format
+   * @return A new typed Literal in {@link RDFTerm} format
+   */
+  export function createDate (date: Moment): TypedLiteral {
+    const value = date.toISOString()
+    return {
+      type: 'literal+type',
+      value: value,
+      datatype: 'http://www.w3.org/2001/XMLSchema#dateTime',
+      asRDF: `"${value}"^^http://www.w3.org/2001/XMLSchema#dateTime`,
+      asJS: date
+    }
+  }
+
+  /**
+   * Clone a literal and replace its value with another one
+   * @param  base     - Literal to clone
+   * @param  newValue - New literal value
+   * @return The literal with its new value
+   */
+  export function replaceLiteralValue (term: RDFTerm, newValue: string): RDFTerm {
+    switch (term.type) {
+      case 'literal+type':
+        return createTypedLiteral(newValue, (<TypedLiteral> term).datatype)
+      case 'literal+lang':
+        return createLangLiteral(newValue, (<LangLiteral> term).lang)
+      default:
+        return createLiteral(newValue)
+    }
+  }
+
+  /**
+   * Test if Two RDF Terms are equals
+   * @see https://www.w3.org/TR/sparql11-query/#func-RDFterm-equal
+   * @param {Object} a - Left Term
+   * @param {Object} b - Right term
+   * @return {Object} A RDF Literal with the results of the test
+   */
+  export function equals (a: RDFTerm, b: RDFTerm): RDFTerm {
+    if (a.type !== b.type) {
       return createBoolean(false)
+    }
+    switch (a.type) {
+      case 'iri':
+      case 'literal':
+        return createBoolean(a.value === b.value)
+      case 'literal+type':
+        return createBoolean(a.value === b.value && (<TypedLiteral> a).datatype === (<TypedLiteral> b).datatype)
+      case 'literal+lang':
+        return createBoolean(a.value === b.value && (<LangLiteral> a).lang === (<LangLiteral> b).lang)
+      default:
+        return createBoolean(false)
+    }
   }
-}
 
-/**
- * Test if a literal is a Date
- * @param  {Object}  literal - Literal to analyze
- * @return {Boolean} True if a literal is a Date, False otherwise
- */
-export function isDate (literal: RDFTerm): boolean {
-    return literal.type === 'literal+type' && (<TypedLiteral> literal).datatype === rdf.XSD('dateTime')
+  /**
+   * Test if a literal is a Date
+   * @param  {Object}  literal - Literal to analyze
+   * @return {Boolean} True if a literal is a Date, False otherwise
+   */
+  export function isDate (literal: RDFTerm): boolean {
+      return literal.type === 'literal+type' && (<TypedLiteral> literal).datatype === rdf.XSD('dateTime')
+  }
 }

--- a/src/rdf-terms.ts
+++ b/src/rdf-terms.ts
@@ -131,6 +131,7 @@ export namespace terms {
 
   /**
    * Creates an IRI in {@link RDFTerm} format
+   * @see https://www.w3.org/TR/rdf11-concepts/#section-IRIs
    * @param iri - IRI
    * @return A new IRI in {@link RDFTerm} format
    */
@@ -145,6 +146,7 @@ export namespace terms {
 
   /**
    * Creates a Literal in {@link RDFTerm} format
+   * @see https://www.w3.org/TR/rdf11-concepts/#section-Graph-Literal
    * @param literal - Literal
    * @return A new Literal in {@link RDFTerm} format
    */
@@ -160,6 +162,7 @@ export namespace terms {
 
   /**
    * Creates a Literal with a datatype, in {@link RDFTerm} format
+   * @see https://www.w3.org/TR/rdf11-concepts/#section-Graph-Literal
    * @param literal - Literal
    * @param type - Literal datatype
    * @return A new typed Literal in {@link RDFTerm} format
@@ -176,6 +179,7 @@ export namespace terms {
 
   /**
    * Creates a Literal with a language tag, in {@link RDFTerm} format
+   * @see https://www.w3.org/TR/rdf11-concepts/#section-Graph-Literal
    * @param literal - Literal
    * @param lang - Language tag
    * @return A new tagged Literal in {@link RDFTerm} format
@@ -258,31 +262,67 @@ export namespace terms {
   /**
    * Test if Two RDF Terms are equals
    * @see https://www.w3.org/TR/sparql11-query/#func-RDFterm-equal
-   * @param {Object} a - Left Term
-   * @param {Object} b - Right term
-   * @return {Object} A RDF Literal with the results of the test
+   * @param left - Left Term
+   * @param right - Right term
+   * @return A RDF Literal with the results of the test (True or False)
    */
-  export function equals (a: RDFTerm, b: RDFTerm): RDFTerm {
-    if (a.type !== b.type) {
+  export function equals (left: RDFTerm, right: RDFTerm): RDFTerm {
+    if (left.type !== right.type) {
       return createBoolean(false)
     }
-    switch (a.type) {
+    switch (left.type) {
       case 'iri':
       case 'literal':
-        return createBoolean(a.value === b.value)
+        return createBoolean(left.value === right.value)
       case 'literal+type':
-        return createBoolean(a.value === b.value && (<TypedLiteral> a).datatype === (<TypedLiteral> b).datatype)
+        return createBoolean(left.value === right.value && (<TypedLiteral> left).datatype === (<TypedLiteral> right).datatype)
       case 'literal+lang':
-        return createBoolean(a.value === b.value && (<LangLiteral> a).lang === (<LangLiteral> b).lang)
+        return createBoolean(left.value === right.value && (<LangLiteral> left).lang === (<LangLiteral> right).lang)
       default:
         return createBoolean(false)
     }
   }
 
   /**
-   * Test if a literal is a Date
-   * @param  {Object}  literal - Literal to analyze
-   * @return {Boolean} True if a literal is a Date, False otherwise
+   * Test if a RDF Term is an IRI
+   * @param  term - RDF Term to test
+   * @return True if the term is an IRI, False otherwise
+   */
+  export function isIRI (term: RDFTerm) {
+    return term.type === 'iri'
+  }
+
+  /**
+   * Test if a RDF Term is a Literal (regardless of the lang/datatype)
+   * @param  term - RDF Term to test
+   * @return True if the term is a Literal, False otherwise
+   */
+  export function isLiteral (term: RDFTerm) {
+    return term.type.startsWith('literal')
+  }
+
+  /**
+   * Test if a RDF Term is a Literal with a datatype
+   * @param  term - RDF Term to test
+   * @return True if the term is a Literal with a datatype, False otherwise
+   */
+  export function isTypedLiteral (term: RDFTerm) {
+    return term.type === 'literal+type'
+  }
+
+  /**
+   * Test if a RDF Term is a Literal with a language
+   * @param  term - RDF Term to test
+   * @return True if the term is a Literal with a language, False otherwise
+   */
+  export function isLangLiteral (term: RDFTerm) {
+    return term.type === 'literal+lang'
+  }
+
+  /**
+   * Test if a RDF Term is a Date literal
+   * @param  literal - RDF Term to test
+   * @return True if the term is a Date literal, False otherwise
    */
   export function isDate (literal: RDFTerm): boolean {
       return literal.type === 'literal+type' && (<TypedLiteral> literal).datatype === rdf.XSD('dateTime')

--- a/src/rdf-terms.ts
+++ b/src/rdf-terms.ts
@@ -327,4 +327,38 @@ export namespace terms {
   export function isDate (literal: RDFTerm): boolean {
       return literal.type === 'literal+type' && (<TypedLiteral> literal).datatype === rdf.XSD('dateTime')
   }
+
+  /**
+   * Test if a RDF Term is a Number literal (float, int, etc)
+   * @param  literal - RDF Term to test
+   * @return True if the term is a Number literal, False otherwise
+   */
+  export function isNumber (term: RDFTerm): boolean {
+      if (term.type !== 'literal+type') {
+        return false;
+      }
+      const literal: TypedLiteral = term as TypedLiteral
+      switch (literal.type) {
+        case rdf.XSD('integer'):
+        case rdf.XSD('byte'):
+        case rdf.XSD('short'):
+        case rdf.XSD('int'):
+        case rdf.XSD('unsignedByte'):
+        case rdf.XSD('unsignedShort'):
+        case rdf.XSD('unsignedInt'):
+        case rdf.XSD('number'):
+        case rdf.XSD('float'):
+        case rdf.XSD('decimal'):
+        case rdf.XSD('double'):
+        case rdf.XSD('long'):
+        case rdf.XSD('unsignedLong'):
+        case rdf.XSD('positiveInteger'):
+        case rdf.XSD('nonPositiveInteger'):
+        case rdf.XSD('negativeInteger'):
+        case rdf.XSD('nonNegativeInteger'):
+          return true;
+        default:
+          return false;
+      }
+  }
 }

--- a/src/rdf-terms.ts
+++ b/src/rdf-terms.ts
@@ -128,7 +128,7 @@ function literalToJS (value: string, type: string): any {
  * @param iri - IRI
  * @return A new IRI in {@link RDFTerm} format
  */
-export function IRIDescriptor (iri: string): IRI {
+export function createIRI (iri: string): IRI {
   return {
     type: 'iri',
     value: iri,
@@ -142,7 +142,7 @@ export function IRIDescriptor (iri: string): IRI {
  * @param literal - Literal
  * @return A new Literal in {@link RDFTerm} format
  */
-export function RawLiteralDescriptor (literal: string): RawLiteral {
+export function createLiteral (literal: string): RawLiteral {
   const rdf = `"${literal}"`
   return {
     type: 'literal',
@@ -158,7 +158,7 @@ export function RawLiteralDescriptor (literal: string): RawLiteral {
  * @param type - Literal datatype
  * @return A new typed Literal in {@link RDFTerm} format
  */
-export function TypedLiteralDescriptor (literal: string, type: string): TypedLiteral {
+export function createTypedLiteral (literal: string, type: string): TypedLiteral {
   return {
     type: 'literal+type',
     value: literal,
@@ -174,7 +174,7 @@ export function TypedLiteralDescriptor (literal: string, type: string): TypedLit
  * @param lang - Language tag
  * @return A new tagged Literal in {@link RDFTerm} format
  */
-export function LangLiteralDescriptor (literal: string, lang: string): LangLiteral {
+export function createLangLiteral (literal: string, lang: string): LangLiteral {
   const rdf = `"${literal}"@${lang}`
   return {
     type: 'literal+lang',
@@ -190,7 +190,7 @@ export function LangLiteralDescriptor (literal: string, lang: string): LangLiter
  * @param value - Boolean
  * @return A new typed Literal in {@link RDFTerm} format
  */
-export function BooleanDescriptor (value: boolean): TypedLiteral {
+export function createBoolean (value: boolean): TypedLiteral {
   return {
     type: 'literal+type',
     value: `"${value}"`,
@@ -206,7 +206,7 @@ export function BooleanDescriptor (value: boolean): TypedLiteral {
  * @param type - Literal type
  * @return A new typed Literal in {@link RDFTerm} format
  */
-export function NumericOperation (value: number, type: string): TypedLiteral {
+export function createNumber (value: number, type: string): TypedLiteral {
   return {
     type: 'literal+type',
     value: value.toString(),
@@ -221,7 +221,7 @@ export function NumericOperation (value: number, type: string): TypedLiteral {
  * @param date - A Date, in Moment format
  * @return A new typed Literal in {@link RDFTerm} format
  */
-export function DateLiteral (date: Moment): TypedLiteral {
+export function createDate (date: Moment): TypedLiteral {
   const value = date.toISOString()
   return {
     type: 'literal+type',

--- a/src/rdf-terms.ts
+++ b/src/rdf-terms.ts
@@ -231,3 +231,53 @@ export function createDate (date: Moment): TypedLiteral {
     asJS: date
   }
 }
+
+/**
+ * Clone a literal and replace its value with another one
+ * @param  base     - Literal to clone
+ * @param  newValue - New literal value
+ * @return The literal with its new value
+ */
+export function replaceLiteralValue (term: RDFTerm, newValue: string): RDFTerm {
+  switch (term.type) {
+    case 'literal+type':
+      return createTypedLiteral(newValue, (<TypedLiteral> term).datatype)
+    case 'literal+lang':
+      return createLangLiteral(newValue, (<LangLiteral> term).lang)
+    default:
+      return createLiteral(newValue)
+  }
+}
+
+/**
+ * Test if Two RDF Terms are equals
+ * @see https://www.w3.org/TR/sparql11-query/#func-RDFterm-equal
+ * @param {Object} a - Left Term
+ * @param {Object} b - Right term
+ * @return {Object} A RDF Literal with the results of the test
+ */
+export function equals (a: RDFTerm, b: RDFTerm): RDFTerm {
+  if (a.type !== b.type) {
+    return createBoolean(false)
+  }
+  switch (a.type) {
+    case 'iri':
+    case 'literal':
+      return createBoolean(a.value === b.value)
+    case 'literal+type':
+      return createBoolean(a.value === b.value && (<TypedLiteral> a).datatype === (<TypedLiteral> b).datatype)
+    case 'literal+lang':
+      return createBoolean(a.value === b.value && (<LangLiteral> a).lang === (<LangLiteral> b).lang)
+    default:
+      return createBoolean(false)
+  }
+}
+
+/**
+ * Test if a literal is a Date
+ * @param  {Object}  literal - Literal to analyze
+ * @return {Boolean} True if a literal is a Date, False otherwise
+ */
+export function isDate (literal: RDFTerm): boolean {
+    return literal.type === 'literal+type' && (<TypedLiteral> literal).datatype === rdf.XSD('dateTime')
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -24,7 +24,7 @@ SOFTWARE.
 
 'use strict'
 
-import * as terms from './rdf-terms'
+import { terms } from './rdf-terms'
 import { Util } from 'n3'
 import { Observable } from 'rxjs'
 import { map } from 'rxjs/operators'

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -57,17 +57,17 @@ export namespace rdf {
   export function parseTerm (term: string): terms.RDFTerm {
     let parsed = null
     if (Util.isIRI(term)) {
-      parsed = terms.IRIDescriptor(term)
+      parsed = terms.createIRI(term)
     } else if (Util.isLiteral(term)) {
       const value = Util.getLiteralValue(term)
       const lang = Util.getLiteralLanguage(term)
       const type = cleanIRI(Util.getLiteralType(term))
       if (lang !== null && lang !== undefined && lang !== '') {
-        parsed = terms.LangLiteralDescriptor(value, lang)
+        parsed = terms.createLangLiteral(value, lang)
       } else if (term.indexOf('^^') > -1) {
-        parsed = terms.TypedLiteralDescriptor(value, type)
+        parsed = terms.createTypedLiteral(value, type)
       } else {
-        parsed = terms.RawLiteralDescriptor(value)
+        parsed = terms.createLiteral(value)
       }
     } else {
       throw new SyntaxError(`Unknown RDF Term encoutered during parsing: ${term}`)

--- a/tests/sparql/custom-functions-test.js
+++ b/tests/sparql/custom-functions-test.js
@@ -33,20 +33,9 @@ describe('SPARQL custom operators', () => {
 
   it('should allow for custom functions in BIND', done => {
 
-    function cloneLiteral(base, newValue) {
-      switch (base.type) {
-        case 'literal+type':
-          return terms.TypedLiteralDescriptor(newValue, base.datatype)
-        case 'literal+lang':
-          return terms.createLangLiteral(newValue, base.lang)
-        default:
-          return terms.RawLiteralDescriptor(newValue)
-      }
-    }
-
     const customFunctions = {
       'http://test.com#REVERSE': function (a) {
-        return cloneLiteral(a, a.value.split("").reverse().join(""))
+        return terms.replaceLiteralValue(a, a.value.split("").reverse().join(""))
       }
     }
 

--- a/tests/sparql/custom-functions-test.js
+++ b/tests/sparql/custom-functions-test.js
@@ -38,7 +38,7 @@ describe('SPARQL custom operators', () => {
         case 'literal+type':
           return terms.TypedLiteralDescriptor(newValue, base.datatype)
         case 'literal+lang':
-          return terms.LangLiteralDescriptor(newValue, base.lang)
+          return terms.createLangLiteral(newValue, base.lang)
         default:
           return terms.RawLiteralDescriptor(newValue)
       }
@@ -78,7 +78,7 @@ describe('SPARQL custom operators', () => {
 
     const customFunctions = {
       'http://test.com#CONTAINS_THOMAS': function (a) {
-        return terms.BooleanDescriptor(a.value.toLowerCase().indexOf("thomas") >= 0)
+        return terms.createBoolean(a.value.toLowerCase().indexOf("thomas") >= 0)
       }
     }
     const g = getGraph('./tests/data/dblp.nt')
@@ -108,7 +108,7 @@ describe('SPARQL custom operators', () => {
 
     const customFunctions = {
       'http://test.com#IS_EVEN': function (a) {
-        return terms.BooleanDescriptor(a.value % 2 === 0)
+        return terms.createBoolean(a.value % 2 === 0)
       }
     }
     const g = getGraph('./tests/data/dblp.nt')
@@ -193,5 +193,3 @@ describe('SPARQL custom operators', () => {
   })
 
 })
-
-

--- a/tests/sparql/custom-functions-test.js
+++ b/tests/sparql/custom-functions-test.js
@@ -26,7 +26,7 @@ SOFTWARE.
 
 const expect = require('chai').expect
 const { XSD } = require('../../dist/utils.js').rdf
-const terms = require('../../dist/rdf-terms')
+const terms = require('../../dist/api').terms
 const { getGraph, TestEngine } = require('../utils.js')
 
 describe('SPARQL custom operators', () => {


### PR DESCRIPTION
Extends the work from #13 in order to ease the development of custom SPARQL functions. The whole `rdf-terms` module API has been revamped, with more utility functions. Finally, this module is now exposed in the package top-level.