### PR TITLE
Fix/18

### DIFF
--- a/src/operators/optional.ts
+++ b/src/operators/optional.ts
@@ -77,7 +77,7 @@ export default function optional (source: Observable<Bindings>, patterns: Algebr
       const index = seenBefore.findIndex((b: Bindings) => {
         return b.isSubset(bindings)
       })
-      if (index > 0) {
+      if (index >= 0) {
         seenBefore.splice(index, 1)
       }
     })), from(seenBefore))

--- a/tests/data/SPARQL-Query-1.1-6.2.ttl
+++ b/tests/data/SPARQL-Query-1.1-6.2.ttl
@@ -1,0 +1,8 @@
+@prefix dc:   <http://purl.org/dc/elements/1.1/> .
+@prefix :     <http://example.org/book/> .
+@prefix ns:   <http://example.org/ns#> .
+
+:book1  dc:title  "SPARQL Tutorial" .
+:book1  ns:price  42 .
+:book2  dc:title  "The Semantic Web" .
+:book2  ns:price  23 .

--- a/tests/sparql/optional-test.js
+++ b/tests/sparql/optional-test.js
@@ -34,6 +34,26 @@ describe('SPARQL queries with OPTIONAL', () => {
     engine = new TestEngine(g)
   })
 
+  it('should not get an extra result when an OPTIONAL value exists', done => {
+    const query = `
+      SELECT * 
+      WHERE {
+        OPTIONAL {
+          VALUES (?s ?p ?o) { ("s" "p" "o") }
+        }
+      }
+    `
+    const results = []
+    const iterator = engine.execute(query)
+    iterator.subscribe(b => {
+      b = b.toObject()
+      results.push(b)
+    }, done, () => {
+      expect(results.length).to.equal(1)
+      done()
+    })
+  })
+
   it('should evaluate OPTIONAL clauses that yield nothing', done => {
     const query = `
     PREFIX dblp-rdf: <https://dblp.uni-trier.de/rdf/schema-2017-04-18#>

--- a/tests/sparql/optional-test.js
+++ b/tests/sparql/optional-test.js
@@ -35,13 +35,19 @@ describe('SPARQL queries with OPTIONAL', () => {
   })
 
   it('should not get an extra result when an OPTIONAL value exists', done => {
+    const graph = getGraph("./tests/data/SPARQL-Query-1.1-6.2.ttl")
+    engine = new TestEngine(graph)
     const query = `
-      SELECT * 
-      WHERE {
-        OPTIONAL {
-          VALUES (?s ?p ?o) { ("s" "p" "o") }
-        }
+    # this is a modified example is from section 6.2 of the SPARQL Spec. It should only product 2 results
+    PREFIX  dc:  <http://purl.org/dc/elements/1.1/>
+    PREFIX  ns:  <http://example.org/ns#>
+    SELECT  ?title ?price
+    WHERE   { 
+      ?x dc:title ?title .
+      OPTIONAL { 
+        ?x ns:price ?price 
       }
+    }
     `
     const results = []
     const iterator = engine.execute(query)
@@ -49,7 +55,8 @@ describe('SPARQL queries with OPTIONAL', () => {
       b = b.toObject()
       results.push(b)
     }, done, () => {
-      expect(results.length).to.equal(1)
+      console.log(results)
+      expect(results.length).to.equal(2)
       done()
     })
   })

--- a/tests/sparql/optional-test.js
+++ b/tests/sparql/optional-test.js
@@ -29,37 +29,12 @@ const { getGraph, TestEngine } = require('../utils.js')
 
 describe('SPARQL queries with OPTIONAL', () => {
   let engine = null
-  before(() => {
+  beforeEach(() => {
     const g = getGraph('./tests/data/dblp_opt.nt')
     engine = new TestEngine(g)
   })
 
-  it('should not get an extra result when an OPTIONAL value exists', done => {
-    const graph = getGraph("./tests/data/SPARQL-Query-1.1-6.2.ttl")
-    engine = new TestEngine(graph)
-    const query = `
-    # this is a modified example is from section 6.2 of the SPARQL Spec. It should only product 2 results
-    PREFIX  dc:  <http://purl.org/dc/elements/1.1/>
-    PREFIX  ns:  <http://example.org/ns#>
-    SELECT  ?title ?price
-    WHERE   { 
-      ?x dc:title ?title .
-      OPTIONAL { 
-        ?x ns:price ?price 
-      }
-    }
-    `
-    const results = []
-    const iterator = engine.execute(query)
-    iterator.subscribe(b => {
-      b = b.toObject()
-      results.push(b)
-    }, done, () => {
-      console.log(results)
-      expect(results.length).to.equal(2)
-      done()
-    })
-  })
+
 
   it('should evaluate OPTIONAL clauses that yield nothing', done => {
     const query = `
@@ -171,4 +146,149 @@ describe('SPARQL queries with OPTIONAL', () => {
       done()
     })
   })
+
+  it('should not get an extra result when an OPTIONAL value exists', done => {
+    const graph = getGraph("./tests/data/SPARQL-Query-1.1-6.2.ttl")
+    engine = new TestEngine(graph)
+    const query = `
+    # this is a modified example is from section 6.2 of the SPARQL Spec. It should only product 2 results
+    PREFIX  dc:  <http://purl.org/dc/elements/1.1/>
+    PREFIX  ns:  <http://example.org/ns#>
+    SELECT  ?title ?price
+    WHERE   { 
+      ?x dc:title ?title .
+      OPTIONAL { 
+        ?x ns:price ?price .
+      }
+    }
+    `
+    const results = []
+    const iterator = engine.execute(query)
+    iterator.subscribe(b => {
+      b = b.toObject()
+      results.push(b)
+    }, done, () => {
+      expect(results.length).to.equal(2)
+      results.map(b => {
+        expect(b['?title']).to.be.oneOf(['"SPARQL Tutorial"', '"The Semantic Web"'])
+        expect(b['?price']).to.be.oneOf([
+          '"42"^^http://www.w3.org/2001/XMLSchema#integer',
+          '"23"^^http://www.w3.org/2001/XMLSchema#integer'
+        ])
+
+      })
+
+      done()
+    })
+  })
+
+  it('should not get an extra result when an OPTIONAL value exists and multiple OPTIONAL clauses are used', done => {
+    const graph = getGraph("./tests/data/SPARQL-Query-1.1-6.2.ttl")
+    engine = new TestEngine(graph)
+    const query = `
+    # this is a modified example is from section 6.2 of the SPARQL Spec. It should only produce 2 results
+    PREFIX  dc:  <http://purl.org/dc/elements/1.1/>
+    PREFIX  ns:  <http://example.org/ns#>
+    SELECT  ?title ?price
+    WHERE   { 
+      OPTIONAL {
+        ?x dc:title ?title .
+      }
+      OPTIONAL { 
+        ?x ns:price ?price .
+      }
+    }
+    `
+    const results = []
+    const iterator = engine.execute(query)
+    iterator.subscribe(b => {
+      b = b.toObject()
+      results.push(b)
+    }, done, () => {
+      expect(results.length).to.equal(2)
+      results.map(b => {
+        expect(b['?title']).to.be.oneOf(['"SPARQL Tutorial"', '"The Semantic Web"'])
+        expect(b['?price']).to.be.oneOf([
+          '"42"^^http://www.w3.org/2001/XMLSchema#integer',
+          '"23"^^http://www.w3.org/2001/XMLSchema#integer'
+        ])
+
+      })
+
+      done()
+    })
+  })
+
+  it('should get the correct number of results when an OPTIONAL results in an UNBOUND', done => {
+    const graph = getGraph("./tests/data/SPARQL-Query-1.1-6.2.ttl")
+    engine = new TestEngine(graph)
+    const query = `
+    # this is a modified example is from section 6.2 of the SPARQL Spec. It should only produce 2 results
+    PREFIX  dc:  <http://purl.org/dc/elements/1.1/>
+    PREFIX  ns:  <http://example.org/ns#>
+    SELECT  ?title ?price
+    WHERE   { 
+      ?x dc:title ?title .
+      OPTIONAL { 
+        ?x ns:price ?price . FILTER(?price > 30)
+      }
+    }
+    `
+    const results = []
+    const iterator = engine.execute(query)
+    iterator.subscribe(b => {
+      b = b.toObject()
+      results.push(b)
+    }, done, () => {
+      expect(results.length).to.equal(2)
+      results.map(b => {
+        expect(b['?title']).to.be.oneOf(['"SPARQL Tutorial"', '"The Semantic Web"'])
+        expect(b['?price']).to.be.oneOf([
+          '"42"^^http://www.w3.org/2001/XMLSchema#integer',
+          'UNBOUND'
+        ])
+
+      })
+
+      done()
+    })
+  })
+
+  it('should get the correct number of results when an OPTIONAL results in an UNBOUND value with multiple OPTIONAL clauses', done => {
+    const graph = getGraph("./tests/data/SPARQL-Query-1.1-6.2.ttl")
+    engine = new TestEngine(graph)
+    const query = `
+    # this is a modified example is from section 6.2 of the SPARQL Spec. It should only produce 2 results
+    PREFIX  dc:  <http://purl.org/dc/elements/1.1/>
+    PREFIX  ns:  <http://example.org/ns#>
+    SELECT  ?title ?price
+    WHERE   { 
+      OPTIONAL {
+        ?x dc:title ?title .
+      }
+      OPTIONAL { 
+        ?x ns:price ?price . FILTER(?price > 30)
+      }
+    }
+    `
+    const results = []
+    const iterator = engine.execute(query)
+    iterator.subscribe(b => {
+      b = b.toObject()
+      results.push(b)
+    }, done, () => {
+      expect(results.length).to.equal(2)
+      results.map(b => {
+        expect(b['?title']).to.be.oneOf(['"SPARQL Tutorial"', '"The Semantic Web"'])
+        expect(b['?price']).to.be.oneOf([
+          '"42"^^http://www.w3.org/2001/XMLSchema#integer',
+          'UNBOUND'
+        ])
+
+      })
+
+      done()
+    })
+  })
+
 })


### PR DESCRIPTION
This is a fix for #18. I noticed that [the zero index was ignored](https://github.com/Callidon/sparql-engine/blob/master/src/operators/optional.ts#L80) when searching the `seenBefore` array. Fixing that resolved my reported issue and all test still pass. That said, it's not clear to me why it fixes the issue, so I think it's worth having @Callidon review this. As an additional note, the comments on the `optional` function don't seem relevant and I believe the `defaultValues` function could be completely removed, but I'll let @Callidon make that call.