### PR TITLE
Externalize pipeline architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ An open-source framework for building SPARQL query engines in Javascript.
 * [Custom Functions](#custom-functions)
 * [Federated SPARQL Queries](#federated-sparql-queries)
 * [Advanced Usage](#advanced-usage)
+  * [Customize the pipeline implementation](#customize-the-pipeline-implementation)
+  * [Customize query execution](#customize-query-execution)
 * [Documentation](#documentation)
 * [References](#references)
 
@@ -287,7 +289,36 @@ Once your custom ServiceExecutor is ready, you need to *install* it on a `PlanBu
 
 # Advanced usage
 
-## Building the Physical Query Execution Plan yourself
+## Customize the pipeline implementation
+
+The class `PipelineEngine` (and its subclasses) is the main component used by `sparql-engine` to evaluate all SPARQL operations. It defines basic operations (`map`, `filter`, etc) that can be used
+to manipulate intermediate results and evaluate SPARQL queries.
+
+By default, the framework uses an implementation of `PipelineEngine` based on [`rxjs`](https://rxjs-dev.firebaseapp.com/), to implements a SPARQL query execution plan as a pipeline of iterators.
+However, **you are able to switch to others implementations** of `PipelineEngine`, using `Pipeline.setInstance`.
+
+```javascript
+const { Pipeline, PipelineEngine } = require('sparql-engine')
+
+class CustomEngine extends PipelineEngine {
+  // ...
+}
+
+// add this before creating a new plan builder
+Pipeline.setInstance(new CustomEngine())
+// ...
+```
+
+Two implementations of `PipelineEngine` are provided by default.
+* `RxjsPipeline`, based on [`rxjs`](https://rxjs-dev.firebaseapp.com/), which provides a pure pipeline approach. This approach is **selected by default** when loading the framework.
+* `VectorPipeline`, which materializes all intermediate results at each pipeline computation step. This approach is more efficient CPU-wise, but also consumes a lot more memory.
+
+These implementations can be imported as follows:
+```javascript
+const { RxjsPipeline, VectorPipeline } = require('sparql-engine')
+```
+
+## Customize query execution
 
 As introduced before, a `PlanBuilder` rely on **Executors** to build the *physical query execution plan*
 of a SPARQL query. If you wish to configure how this plan is built, then you just have to extends the various executors

--- a/src/api.ts
+++ b/src/api.ts
@@ -29,6 +29,11 @@ export { BindingBase } from './rdf/bindings'
 export { default as HashMapDataset } from './rdf/hashmap-dataset'
 export { default as Graph } from './rdf/graph'
 export { default as PlanBuilder } from './engine/plan-builder'
+// pipeline
+export { Pipeline } from './engine/pipeline/pipeline'
+export { PipelineEngine } from './engine/pipeline/pipeline-engine'
+export { default as RxjsPipeline } from './engine/pipeline/rxjs-pipeline'
+export { default as VectorPipeline } from './engine/pipeline/vector-pipeline'
 // executors
 export { default as AggregateExecutor } from './engine/executors/aggregate-executor'
 export { default as BGPExecutor } from './engine/executors/bgp-executor'
@@ -36,6 +41,6 @@ export { default as GraphExecutor } from './engine/executors/graph-executor'
 export { default as ServiceExecutor } from './engine/executors/service-executor'
 export { default as UpdateExecutor } from './engine/executors/update-executor'
 // RDF terms Utilities
-export { terms } from './rdf-terms' 
+export { terms } from './rdf-terms'
 // formatters
 // export { default as XMLFormatter } from './formatters/xml-formatter'

--- a/src/engine/executors/aggregate-executor.ts
+++ b/src/engine/executors/aggregate-executor.ts
@@ -78,7 +78,7 @@ export default class AggregateExecutor extends Executor {
         variables.push(g.expression)
       } else {
         variables.push(g.variable)
-        iterator = iterator.pipe(bind(g.variable, g.expression, customFunctions))
+        iterator = bind(iterator, g.variable, g.expression, customFunctions)
       }
     })
     return groupBy(iterator, variables)

--- a/src/engine/executors/aggregate-executor.ts
+++ b/src/engine/executors/aggregate-executor.ts
@@ -43,11 +43,11 @@ import ExecutionContext from '../context/execution-context'
  */
 export default class AggregateExecutor extends Executor {
   /**
-   * Build an iterator for the evaluation of SPARQL aggregations
-   * @param source  - Source iterator
+   * Build a {@link PipelineStage} for the evaluation of SPARQL aggregations
+   * @param source  - Input {@link PipelineStage}
    * @param query   - Parsed SPARQL query (logical execution plan)
    * @param options - Execution options
-   * @return An iterator which evaluate SPARQL aggregations
+   * @return A {@link PipelineStage} which evaluate SPARQL aggregations
    */
   buildIterator (source: PipelineStage<Bindings>, query: Algebra.RootNode, context: ExecutionContext, customFunctions?: CustomFunctions): PipelineStage<Bindings> {
     if ('group' in query) {
@@ -63,11 +63,11 @@ export default class AggregateExecutor extends Executor {
   }
 
   /**
-   * Build an iterator for the evaluation of a GROUP BY clause
-   * @param source  - Source iterator
+   * Build a {@link PipelineStage} for the evaluation of a GROUP BY clause
+   * @param source  - Input {@link PipelineStage}
    * @param  groupby - GROUP BY clause
    * @param  options - Execution options
-   * @return An iterator which evaluate a GROUP BY clause
+   * @return A {@link PipelineStage} which evaluate a GROUP BY clause
    */
   _executeGroupBy (source: PipelineStage<Bindings>, groupby: Algebra.Aggregation[], context: ExecutionContext, customFunctions?: CustomFunctions): PipelineStage<Bindings> {
     let iterator = source
@@ -85,11 +85,11 @@ export default class AggregateExecutor extends Executor {
   }
 
   /**
-   * Build an iterator for the evaluation of a HAVING clause
-   * @param  source  - Source iterator
+   * Build a {@link PipelineStage} for the evaluation of a HAVING clause
+   * @param  source  - Input {@link PipelineStage}
    * @param  having  - HAVING clause
    * @param  options - Execution options
-   * @return An iterator which evaluate a HAVING clause
+   * @return A {@link PipelineStage} which evaluate a HAVING clause
    */
   _executeHaving (source: PipelineStage<Bindings>, having: Algebra.Expression[], context: ExecutionContext, customFunctions?: CustomFunctions): PipelineStage<Bindings> {
     // thanks to the flexibility of SPARQL expressions,

--- a/src/engine/executors/aggregate-executor.ts
+++ b/src/engine/executors/aggregate-executor.ts
@@ -24,7 +24,7 @@ SOFTWARE.
 
 'use strict'
 
-import { Observable } from 'rxjs'
+import { PipelineStage } from '../pipeline/pipeline-engine'
 import Executor from './executor'
 import { CustomFunctions } from '../../engine/plan-builder'
 import bind from '../../operators/bind'
@@ -49,7 +49,7 @@ export default class AggregateExecutor extends Executor {
    * @param options - Execution options
    * @return An iterator which evaluate SPARQL aggregations
    */
-  buildIterator (source: Observable<Bindings>, query: Algebra.RootNode, context: ExecutionContext, customFunctions?: CustomFunctions): Observable<Bindings> {
+  buildIterator (source: PipelineStage<Bindings>, query: Algebra.RootNode, context: ExecutionContext, customFunctions?: CustomFunctions): PipelineStage<Bindings> {
     if ('group' in query) {
       // first, group bindings using the GROUP BY clause
       let iterator = this._executeGroupBy(source, query.group || [], context, customFunctions)
@@ -69,7 +69,7 @@ export default class AggregateExecutor extends Executor {
    * @param  options - Execution options
    * @return An iterator which evaluate a GROUP BY clause
    */
-  _executeGroupBy (source: Observable<Bindings>, groupby: Algebra.Aggregation[], context: ExecutionContext, customFunctions?: CustomFunctions): Observable<Bindings> {
+  _executeGroupBy (source: PipelineStage<Bindings>, groupby: Algebra.Aggregation[], context: ExecutionContext, customFunctions?: CustomFunctions): PipelineStage<Bindings> {
     let iterator = source
     // extract GROUP By variables & rewrite SPARQL expressions into BIND clauses
     const variables: string[] = []
@@ -91,11 +91,11 @@ export default class AggregateExecutor extends Executor {
    * @param  options - Execution options
    * @return An iterator which evaluate a HAVING clause
    */
-  _executeHaving (source: Observable<Bindings>, having: Algebra.Expression[], context: ExecutionContext, customFunctions?: CustomFunctions): Observable<Bindings> {
+  _executeHaving (source: PipelineStage<Bindings>, having: Algebra.Expression[], context: ExecutionContext, customFunctions?: CustomFunctions): PipelineStage<Bindings> {
     // thanks to the flexibility of SPARQL expressions,
     // we can rewrite a HAVING clause in a set of FILTER clauses!
     return having.reduce((iter, expression) => {
-      return iter.pipe(filter(expression, customFunctions))
+      return filter(iter, expression, customFunctions)
     }, source)
   }
 }

--- a/src/engine/executors/bgp-executor.ts
+++ b/src/engine/executors/bgp-executor.ts
@@ -25,34 +25,34 @@ SOFTWARE.
 'use strict'
 
 import Executor from './executor'
-import { Observable, from } from 'rxjs'
-import { map, mergeMap } from 'rxjs/operators'
+import { Pipeline } from '../pipeline/pipeline'
+import { PipelineStage } from '../pipeline/pipeline-engine'
 // import { some } from 'lodash'
 import { Algebra } from 'sparqljs'
 import Graph from '../../rdf/graph'
 import Dataset from '../../rdf/dataset'
 import { Bindings } from '../../rdf/bindings'
-import { GRAPH_CAPABILITY } from '../../rdf/graph_capability'
+// import { GRAPH_CAPABILITY } from '../../rdf/graph_capability'
 import { parseHints } from '../context/query-hints'
 import ExecutionContext from '../context/execution-context'
 
-import boundJoin from '../../operators/join/bound-join'
+// import boundJoin from '../../operators/join/bound-join'
 
 /**
  * Basic iterator used to evaluate Basic graph patterns using the "evalBGP" method
  * available
  * @private
  */
- function bgpEvaluation (bgp: Algebra.TripleObject[], graph: Graph, context: ExecutionContext) {
-   return mergeMap((bindings: Bindings) => {
+ function bgpEvaluation (source: PipelineStage<Bindings>, bgp: Algebra.TripleObject[], graph: Graph, context: ExecutionContext) {
+   const engine = Pipeline.getInstance()
+   return engine.mergeMap(source, (bindings: Bindings) => {
      let boundedBGP = bgp.map(t => bindings.bound(t))
      // const hasVars = boundedBGP.map(p => some(p, v => v!.startsWith('?')))
      //   .reduce((acc, v) => acc && v, true)
-     return from(graph.evalBGP(boundedBGP, context))
-       .pipe(map((item: Bindings) => {
-         // if (item.size === 0 && hasVars) return null
-         return item.union(bindings)
-       }))
+     return engine.map(graph.evalBGP(boundedBGP, context), (item: Bindings) => {
+       // if (item.size === 0 && hasVars) return null
+       return item.union(bindings)
+     })
    })
  }
 
@@ -98,7 +98,7 @@ export default class BGPExecutor extends Executor {
    * @param  options   - Execution options
    * @return An iterator used to evaluate a Basic Graph pattern
    */
-  buildIterator (source: Observable<Bindings>, patterns: Algebra.TripleObject[], context: ExecutionContext): Observable<Bindings> {
+  buildIterator (source: PipelineStage<Bindings>, patterns: Algebra.TripleObject[], context: ExecutionContext): PipelineStage<Bindings> {
     // select the graph to use for BGP evaluation
     const graph = (context.defaultGraphs.length > 0) ? this._getGraph(context.defaultGraphs) : this._dataset.getDefaultGraph()
     // extract eventual query hints from the BGP & merge them into the context
@@ -108,7 +108,7 @@ export default class BGPExecutor extends Executor {
     const [bgp, artificals] = this._replaceBlankNodes(extraction[0])
     let iterator = this._execute(source, graph, bgp, context)
     if (artificals.length > 0) {
-      iterator = iterator.pipe(map(b => b.filter(variable => artificals.indexOf(variable) < 0)))
+      iterator = Pipeline.getInstance().map(iterator, (b: Bindings) => b.filter(variable => artificals.indexOf(variable) < 0))
     }
     return iterator
   }
@@ -149,10 +149,10 @@ export default class BGPExecutor extends Executor {
    * @param  isJoinIdentity - True if the source iterator is the starting iterator of the pipeline
    * @return An iterator used to evaluate a Basic Graph pattern
    */
-  _execute (source: Observable<Bindings>, graph: Graph, patterns: Algebra.TripleObject[], context: ExecutionContext): Observable<Bindings> {
-    if (graph._isCapable(GRAPH_CAPABILITY.UNION)) {
-      return boundJoin(source, patterns, graph, context)
-    }
-    return source.pipe(bgpEvaluation(patterns, graph, context))
+  _execute (source: PipelineStage<Bindings>, graph: Graph, patterns: Algebra.TripleObject[], context: ExecutionContext): PipelineStage<Bindings> {
+    // if (graph._isCapable(GRAPH_CAPABILITY.UNION)) {
+    //   return boundJoin(source, patterns, graph, context)
+    // }
+    return bgpEvaluation(source, patterns, graph, context)
   }
 }

--- a/src/engine/executors/bgp-executor.ts
+++ b/src/engine/executors/bgp-executor.ts
@@ -39,7 +39,7 @@ import ExecutionContext from '../context/execution-context'
 // import boundJoin from '../../operators/join/bound-join'
 
 /**
- * Basic iterator used to evaluate Basic graph patterns using the "evalBGP" method
+ * Basic {@link PipelineStage} used to evaluate Basic graph patterns using the "evalBGP" method
  * available
  * @private
  */
@@ -92,11 +92,11 @@ export default class BGPExecutor extends Executor {
   }
 
   /**
-   * Build an iterator to evaluate a BGP
-   * @param  source    - Source iterator
+   * Build a {@link PipelineStage} to evaluate a BGP
+   * @param  source    - Input {@link PipelineStage}
    * @param  patterns  - Set of triple patterns
    * @param  options   - Execution options
-   * @return An iterator used to evaluate a Basic Graph pattern
+   * @return A {@link PipelineStage} used to evaluate a Basic Graph pattern
    */
   buildIterator (source: PipelineStage<Bindings>, patterns: Algebra.TripleObject[], context: ExecutionContext): PipelineStage<Bindings> {
     // select the graph to use for BGP evaluation
@@ -141,13 +141,13 @@ export default class BGPExecutor extends Executor {
   }
 
   /**
-   * Returns an iterator used to evaluate a Basic Graph pattern
-   * @param  source         - Source iterator
+   * Returns a {@link PipelineStage} used to evaluate a Basic Graph pattern
+   * @param  source         - Input {@link PipelineStage}
    * @param  graph          - The graph on which the BGP should be executed
    * @param  patterns       - Set of triple patterns
    * @param  options        - Execution options
    * @param  isJoinIdentity - True if the source iterator is the starting iterator of the pipeline
-   * @return An iterator used to evaluate a Basic Graph pattern
+   * @return A {@link PipelineStage} used to evaluate a Basic Graph pattern
    */
   _execute (source: PipelineStage<Bindings>, graph: Graph, patterns: Algebra.TripleObject[], context: ExecutionContext): PipelineStage<Bindings> {
     // if (graph._isCapable(GRAPH_CAPABILITY.UNION)) {

--- a/src/engine/executors/executor.ts
+++ b/src/engine/executors/executor.ts
@@ -27,7 +27,7 @@ SOFTWARE.
 import PlanBuilder from '../plan-builder'
 
 /**
- * An Executor encaspulate a strategy for executing SPARQL operations
+ * An Executor encapsulate a strategy for executing SPARQL operations
  * @abstract
  * @author Thomas Minier
  */

--- a/src/engine/executors/graph-executor.ts
+++ b/src/engine/executors/graph-executor.ts
@@ -50,11 +50,11 @@ export default class GraphExecutor extends Executor {
   }
 
   /**
-   * Build an iterator to evaluate a GRAPH clause
-   * @param  source  - Source iterator
+   * Build a {@link PipelineStage} to evaluate a GRAPH clause
+   * @param  source  - Input {@link PipelineStage}
    * @param  node    - Graph clause
    * @param  options - Execution options
-   * @return An iterator used to evaluate a GRAPH clause
+   * @return A {@link PipelineStage} used to evaluate a GRAPH clause
    */
   buildIterator (source: PipelineStage<Bindings>, node: Algebra.GraphNode, context: ExecutionContext): PipelineStage<Bindings> {
     let subquery: Algebra.RootNode
@@ -87,12 +87,12 @@ export default class GraphExecutor extends Executor {
   }
 
   /**
-   * Returns an iterator used to evaluate a GRAPH clause
-   * @param  source    - Source iterator
+   * Returns a {@link PipelineStage} used to evaluate a GRAPH clause
+   * @param  source    - Input {@link PipelineStage}
    * @param  iri       - IRI of the GRAPH clause
    * @param  subquery  - Subquery to be evaluated
    * @param  options   - Execution options
-   * @return An iterator used to evaluate a GRAPH clause
+   * @return A {@link PipelineStage} used to evaluate a GRAPH clause
    */
   _execute (source: PipelineStage<Bindings>, iri: string, subquery: Algebra.RootNode, context: ExecutionContext): PipelineStage<Bindings> {
     const opts = context.clone()

--- a/src/engine/executors/path-executor.ts
+++ b/src/engine/executors/path-executor.ts
@@ -90,10 +90,11 @@ export default abstract class PathExecutor extends Executor {
   }
 
   /**
-   * Get an observable for evaluating a succession of property paths, connected by joins.
+   * Get a {@link PipelineStage} for evaluating a succession of property paths, connected by joins.
+   * @param source - Input {@link PipelineStage}
    * @param  triples - Triple patterns
    * @param  context - Execution context
-   * @return An Observable which yield set of bindings from the pipeline of joins
+   * @return A {@link PipelineStage} which yield set of bindings from the pipeline of joins
    */
   executeManyPaths (source: PipelineStage<Bindings>, triples: Algebra.PathTripleObject[], context: ExecutionContext): PipelineStage<Bindings> {
     // create a join pipeline between all property paths using an index join
@@ -107,12 +108,12 @@ export default abstract class PathExecutor extends Executor {
   }
 
   /**
-   * Get an observable for evaluating the property path.
+   * Get a {@link PipelineStage} for evaluating the property path.
    * @param  subject - Path subject
    * @param  path  - Property path
    * @param  obj   - Path object
    * @param  context - Execution context
-   * @return An Observable which yield set of bindings
+   * @return A {@link PipelineStage} which yield set of bindings
    */
   buildIterator(subject: string, path: Algebra.PropertyPath, obj: string, context: ExecutionContext): PipelineStage<Bindings> {
     const graph = (context.defaultGraphs.length > 0) ? this._getGraph(context.defaultGraphs) : this._dataset.getDefaultGraph()
@@ -136,7 +137,7 @@ export default abstract class PathExecutor extends Executor {
    * @param  obj   - Path object
    * @param  graph - RDF graph
    * @param  context - Execution context
-   * @return An Observable which yield RDF triples matching the property path
+   * @return A {@link PipelineStage} which yield RDF triples matching the property path
    */
   abstract _execute(subject: string, path: Algebra.PropertyPath, obj: string, graph: Graph, context: ExecutionContext): PipelineStage<Algebra.TripleObject>
 }

--- a/src/engine/executors/path-executor.ts
+++ b/src/engine/executors/path-executor.ts
@@ -23,8 +23,8 @@ SOFTWARE.
 */
 
 import Executor from './executor'
-import { Observable } from 'rxjs'
-import { map, mergeMap } from 'rxjs/operators'
+import { Pipeline } from '../pipeline/pipeline'
+import { PipelineStage } from '../pipeline/pipeline-engine'
 import { Algebra } from 'sparqljs'
 import { Bindings, BindingBase } from '../../rdf/bindings'
 import Dataset from '../../rdf/dataset'
@@ -95,14 +95,14 @@ export default abstract class PathExecutor extends Executor {
    * @param  context - Execution context
    * @return An Observable which yield set of bindings from the pipeline of joins
    */
-  executeManyPaths (source: Observable<Bindings>, triples: Algebra.PathTripleObject[], context: ExecutionContext): Observable<Bindings> {
+  executeManyPaths (source: PipelineStage<Bindings>, triples: Algebra.PathTripleObject[], context: ExecutionContext): PipelineStage<Bindings> {
     // create a join pipeline between all property paths using an index join
-    return triples.reduce((iter: Observable<Bindings>, triple: Algebra.PathTripleObject) => {
-      return iter.pipe(mergeMap(bindings => {
+    const engine = Pipeline.getInstance()
+    return triples.reduce((iter: PipelineStage<Bindings>, triple: Algebra.PathTripleObject) => {
+      return engine.mergeMap(iter, bindings => {
         const {subject, predicate, object} = boundPathTriple(triple, bindings)
-        return this.buildIterator(subject, predicate, object, context)
-          .pipe(map(b => bindings.union(b)))
-      }))
+        return engine.map(this.buildIterator(subject, predicate, object, context), (b: Bindings) => bindings.union(b))
+      })
     }, source)
   }
 
@@ -114,10 +114,10 @@ export default abstract class PathExecutor extends Executor {
    * @param  context - Execution context
    * @return An Observable which yield set of bindings
    */
-  buildIterator(subject: string, path: Algebra.PropertyPath, obj: string, context: ExecutionContext): Observable<Bindings> {
+  buildIterator(subject: string, path: Algebra.PropertyPath, obj: string, context: ExecutionContext): PipelineStage<Bindings> {
     const graph = (context.defaultGraphs.length > 0) ? this._getGraph(context.defaultGraphs) : this._dataset.getDefaultGraph()
     const evaluator = this._execute(subject, path, obj, graph, context)
-    return evaluator.pipe(map((triple: Algebra.TripleObject) => {
+    return Pipeline.getInstance().map(evaluator, (triple: Algebra.TripleObject) => {
       const temp = {}
       if (rdf.isVariable(subject)) {
         temp[subject] = triple.subject
@@ -126,7 +126,7 @@ export default abstract class PathExecutor extends Executor {
         temp[obj] = triple.object
       }
       return BindingBase.fromObject(temp)
-    }))
+    })
   }
 
   /**
@@ -138,5 +138,5 @@ export default abstract class PathExecutor extends Executor {
    * @param  context - Execution context
    * @return An Observable which yield RDF triples matching the property path
    */
-  abstract _execute(subject: string, path: Algebra.PropertyPath, obj: string, graph: Graph, context: ExecutionContext): Observable<Algebra.TripleObject>
+  abstract _execute(subject: string, path: Algebra.PropertyPath, obj: string, graph: Graph, context: ExecutionContext): PipelineStage<Algebra.TripleObject>
 }

--- a/src/engine/executors/service-executor.ts
+++ b/src/engine/executors/service-executor.ts
@@ -26,7 +26,7 @@ SOFTWARE.
 
 import Executor from './executor'
 import { Algebra } from 'sparqljs'
-import { Observable } from 'rxjs'
+import { PipelineStage } from '../pipeline/pipeline-engine'
 import { Bindings } from '../../rdf/bindings'
 import ExecutionContext from '../context/execution-context'
 
@@ -44,7 +44,7 @@ export default abstract class ServiceExecutor extends Executor {
    * @param  options - Execution options
    * @return An iterator used to evaluate a SERVICE clause
    */
-  buildIterator (source: Observable<Bindings>, node: Algebra.ServiceNode, context: ExecutionContext): Observable<Bindings> {
+  buildIterator (source: PipelineStage<Bindings>, node: Algebra.ServiceNode, context: ExecutionContext): PipelineStage<Bindings> {
     let subquery: Algebra.RootNode
     if (node.patterns[0].type === 'query') {
       subquery = (<Algebra.RootNode> node.patterns[0])
@@ -69,5 +69,5 @@ export default abstract class ServiceExecutor extends Executor {
    * @param options   - Execution options
    * @return An iterator used to evaluate a SERVICE clause
    */
-  abstract _execute (source: Observable<Bindings>, iri: string, subquery: Algebra.RootNode, context: ExecutionContext): Observable<Bindings>
+  abstract _execute (source: PipelineStage<Bindings>, iri: string, subquery: Algebra.RootNode, context: ExecutionContext): PipelineStage<Bindings>
 }

--- a/src/engine/executors/service-executor.ts
+++ b/src/engine/executors/service-executor.ts
@@ -38,11 +38,11 @@ import ExecutionContext from '../context/execution-context'
  */
 export default abstract class ServiceExecutor extends Executor {
   /**
-   * Build an iterator to evaluate a SERVICE clause
-   * @param  source  - Source iterator
+   * Build a {@link PipelineStage} to evaluate a SERVICE clause
+   * @param  source  - Input {@link PipelineStage}
    * @param  node    - Service clause
    * @param  options - Execution options
-   * @return An iterator used to evaluate a SERVICE clause
+   * @return A {@link PipelineStage} used to evaluate a SERVICE clause
    */
   buildIterator (source: PipelineStage<Bindings>, node: Algebra.ServiceNode, context: ExecutionContext): PipelineStage<Bindings> {
     let subquery: Algebra.RootNode
@@ -61,13 +61,13 @@ export default abstract class ServiceExecutor extends Executor {
   }
 
   /**
-   * Returns an iterator used to evaluate a SERVICE clause
+   * Returns a {@link PipelineStage} used to evaluate a SERVICE clause
    * @abstract
-   * @param source    - Source iterator
+   * @param source    - Input {@link PipelineStage}
    * @param iri       - Iri of the SERVICE clause
    * @param subquery  - Subquery to be evaluated
    * @param options   - Execution options
-   * @return An iterator used to evaluate a SERVICE clause
+   * @return A {@link PipelineStage} used to evaluate a SERVICE clause
    */
   abstract _execute (source: PipelineStage<Bindings>, iri: string, subquery: Algebra.RootNode, context: ExecutionContext): PipelineStage<Bindings>
 }

--- a/src/engine/executors/update-executor.ts
+++ b/src/engine/executors/update-executor.ts
@@ -25,8 +25,8 @@ SOFTWARE.
 'use strict'
 
 import Executor from './executor'
-import { Observable, of } from 'rxjs'
-import { shareReplay } from 'rxjs/operators'
+import { Pipeline } from '../pipeline/pipeline'
+import { PipelineStage } from '../pipeline/pipeline-engine'
 import { Consumable, ErrorConsumable } from '../../operators/update/consumer'
 import InsertConsumer from '../../operators/update/insert-consumer'
 import DeleteConsumer from '../../operators/update/delete-consumer'
@@ -112,7 +112,8 @@ export default class UpdateExecutor extends Executor {
    * @return A Consumer used to evaluate SPARQL UPDATE queries
    */
   _handleInsertDelete (update: Algebra.UpdateQueryNode, context: ExecutionContext): Consumable {
-    let source: Observable<Bindings> = of(new BindingBase())
+    const engine = Pipeline.getInstance()
+    let source: PipelineStage<Bindings> = engine.of(new BindingBase())
     let graph: Graph | null = null
     let consumables: Consumable[] = []
 
@@ -132,7 +133,7 @@ export default class UpdateExecutor extends Executor {
     }
 
     // clone the source first
-    source = source.pipe(shareReplay(5))
+    source = engine.clone(source)
 
     // build consumers to evaluate DELETE clauses
     if ('delete' in update && update.delete!.length > 0) {
@@ -158,7 +159,7 @@ export default class UpdateExecutor extends Executor {
    * @param graph - RDF Graph used to insert data
    * @return A consumer used to evaluate a SPARQL INSERT clause
    */
-  _buildInsertConsumer (source: Observable<Bindings>, group: Algebra.BGPNode | Algebra.UpdateGraphNode, graph: Graph | null, context: ExecutionContext): InsertConsumer {
+  _buildInsertConsumer (source: PipelineStage<Bindings>, group: Algebra.BGPNode | Algebra.UpdateGraphNode, graph: Graph | null, context: ExecutionContext): InsertConsumer {
     const tripleSource = construct(source, {template: group.triples})
     if (graph === null) {
       graph = (group.type === 'graph' && 'name' in group) ? this._dataset.getNamedGraph(group.name) : this._dataset.getDefaultGraph()
@@ -174,7 +175,7 @@ export default class UpdateExecutor extends Executor {
    * @param  graph - RDF Graph used to delete data
    * @return A consumer used to evaluate a SPARQL DELETE clause
    */
-  _buildDeleteConsumer (source: Observable<Bindings>, group: Algebra.BGPNode | Algebra.UpdateGraphNode, graph: Graph | null, context: ExecutionContext): DeleteConsumer {
+  _buildDeleteConsumer (source: PipelineStage<Bindings>, group: Algebra.BGPNode | Algebra.UpdateGraphNode, graph: Graph | null, context: ExecutionContext): DeleteConsumer {
     const tripleSource = construct(source, {template: group.triples})
     if (graph === null) {
       graph = (group.type === 'graph' && 'name' in group) ? this._dataset.getNamedGraph(group.name) : this._dataset.getDefaultGraph()

--- a/src/engine/executors/update-executor.ts
+++ b/src/engine/executors/update-executor.ts
@@ -154,7 +154,7 @@ export default class UpdateExecutor extends Executor {
   /**
    * Build a consumer to evaluate a SPARQL INSERT clause
    * @private
-   * @param source - Source iterator
+   * @param source - Input {@link PipelineStage}
    * @param group - parsed SPARQL INSERT clause
    * @param graph - RDF Graph used to insert data
    * @return A consumer used to evaluate a SPARQL INSERT clause
@@ -170,7 +170,7 @@ export default class UpdateExecutor extends Executor {
   /**
    * Build a consumer to evaluate a SPARQL DELETE clause
    * @private
-   * @param  source - Source iterator
+   * @param  source - Input {@link PipelineStage}
    * @param  group - parsed SPARQL DELETE clause
    * @param  graph - RDF Graph used to delete data
    * @return A consumer used to evaluate a SPARQL DELETE clause

--- a/src/engine/pipeline/pipeline-engine.ts
+++ b/src/engine/pipeline/pipeline-engine.ts
@@ -75,6 +75,13 @@ export abstract class PipelineEngine {
   abstract from<T>(value: ObservableInput<T>): PipelineStage<T>;
 
   /**
+   * Clone a PipelineStage
+   * @param  stage - PipelineStage to clone
+   * @return Cloned PipelineStage
+   */
+  abstract clone<T>(stage: PipelineStage<T>): PipelineStage<T>;
+
+  /**
    * Creates an output PipelineStage which concurrently emits all values from every given input PipelineStage.
    * @param  inputs - Inputs PipelineStage
    * @return Output PipelineStage

--- a/src/engine/pipeline/pipeline-engine.ts
+++ b/src/engine/pipeline/pipeline-engine.ts
@@ -58,7 +58,7 @@ export abstract class PipelineEngine {
    * Creates a PipelineStage that emits no items
    * @return A PipelineStage that emits no items
    */
-  abstract empty(): PipelineStage<void>;
+  abstract empty<T>(): PipelineStage<T>;
 
   /**
    * Converts the arguments to a PipelineStage

--- a/src/engine/pipeline/pipeline-engine.ts
+++ b/src/engine/pipeline/pipeline-engine.ts
@@ -131,7 +131,7 @@ export abstract class PipelineEngine {
    * @param  reducer - Accumulator function
    * @return A PipelineStage that emits a single value that is the result of accumulating the values emitted by the source PipelineStage.
    */
-  abstract reduce<F,T>(input: PipelineStage<F>, reducer: (acc: T, value: F) => T, initial?: T): PipelineStage<T>;
+  abstract reduce<F,T>(input: PipelineStage<F>, reducer: (acc: T, value: F) => T, initial: T): PipelineStage<T>;
 
   /**
    * Emits only the first `count` values emitted by the source PipelineStage.

--- a/src/engine/pipeline/pipeline-engine.ts
+++ b/src/engine/pipeline/pipeline-engine.ts
@@ -24,7 +24,10 @@ SOFTWARE.
 
 'use strict'
 
-import { ObservableInput } from 'rxjs'
+/**
+ * The input of a {@link PipelineStage}, either another {@link PipelineStage}, an array, an iterable or a promise.
+ */
+export type PipelineInput<T> = PipelineStage<T> | Iterable<T> | PromiseLike<T> | ArrayLike<T>;
 
 /**
  * A step in a pipeline. Data can be consumed in a pull-based or push-bashed fashion.
@@ -72,7 +75,7 @@ export abstract class PipelineEngine {
    * @param  value - Source object
    * @return A PipelineStage that emits the values contains in the object
    */
-  abstract from<T>(value: ObservableInput<T>): PipelineStage<T>;
+  abstract from<T>(value: PipelineInput<T>): PipelineStage<T>;
 
   /**
    * Clone a PipelineStage
@@ -86,7 +89,7 @@ export abstract class PipelineEngine {
    * @param  inputs - Inputs PipelineStage
    * @return Output PipelineStage
    */
-  abstract merge<T>(...inputs: PipelineStage<T>[]): PipelineStage<T>;
+  abstract merge<T>(...inputs: Array<PipelineStage<T> | PipelineInput<T>>): PipelineStage<T>;
 
   /**
    * Applies a given `mapper` function to each value emitted by the source PipelineStage, and emits the resulting values as a PipelineStage.

--- a/src/engine/pipeline/pipeline-engine.ts
+++ b/src/engine/pipeline/pipeline-engine.ts
@@ -140,9 +140,10 @@ export abstract class PipelineEngine {
   /**
    * Returns a PipelineStage that emits all items emitted by the source PipelineStage that are distinct by comparison from previous items.
    * @param  input - Input PipelineStage
+   * @param  selector - Optional function to select which value you want to check as distinct.
    * @return A PipelineStage that emits items from the source PipelineStage with distinct values.
    */
-  abstract distinct<T>(input: PipelineStage<T>): PipelineStage<T>;
+  abstract distinct<T, K>(input: PipelineStage<T>, selector?: (value: T) => K): PipelineStage<T>;
 
   /**
    * Apply a callback on every item emitted by the source PipelineStage

--- a/src/engine/pipeline/pipeline-engine.ts
+++ b/src/engine/pipeline/pipeline-engine.ts
@@ -47,8 +47,8 @@ export interface PipelineStage<T> {
 }
 
 /**
- * Abstract representation of a pipeline of iterators.
- * Concrete subclasses are used by the fremwork to build the query execution pipeline.
+ * Abstract representation used to apply transformations on a pipeline of iterators.
+ * Concrete subclasses are used by the framework to build the query execution pipeline.
  * @abstract
  * @author Thomas Minier
  */

--- a/src/engine/pipeline/pipeline-engine.ts
+++ b/src/engine/pipeline/pipeline-engine.ts
@@ -1,0 +1,199 @@
+/* file : pipeline-engine.ts
+MIT License
+
+Copyright (c) 2019 Thomas Minier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+'use strict'
+
+import { ObservableInput } from 'rxjs'
+
+/**
+ * A step in a pipeline. Data can be consumed in a pull-based or push-bashed fashion.
+ * @author Thomas Minier
+ */
+export interface PipelineStage<T> {
+
+  subscribe(onData: (value: T) => void, onError: (err: any) => void, onEnd: () => void): void;
+
+  forEach(cb: (value: T) => void): void;
+}
+
+/**
+ * Abstract representation of a pipeline of iterators.
+ * Concrete subclasses are used by the fremwork to build the query execution pipeline.
+ * @abstract
+ * @author Thomas Minier
+ */
+export abstract class PipelineEngine<T, O extends PipelineStage<T>, B extends PipelineStage<T[]>> {
+
+  /**
+   * Creates a PipelineStage that emits no items
+   * @return A PipelineStage that emits no items
+   */
+  abstract empty(): O;
+
+  /**
+   * Converts the arguments to a PipelineStage
+   * @param  values - Values to convert
+   * @return A PipelineStage that emits the values
+   */
+  abstract of(...values: T[]): O;
+
+  /**
+   * Creates a PipelineStage from an Array, an array-like object, a Promise, an iterable object, or an Observable-like object.
+   * @param  value - Source object
+   * @return A PipelineStage that emits the values contains in the object
+   */
+  abstract from(value: ObservableInput<T>): O;
+
+  /**
+   * Creates an output PipelineStage which concurrently emits all values from every given input PipelineStage.
+   * @param  inputs - Inputs PipelineStage
+   * @return Output PipelineStage
+   */
+  abstract merge(...inputs: O[]): O;
+
+  /**
+   * Applies a given `mapper` function to each value emitted by the source PipelineStage, and emits the resulting values as a PipelineStage.
+   * @param  input  - Source PipelineStage
+   * @param  mapper - The function to apply to each value emitted by the source PipelineStage
+   * @return A PipelineStage that emits the values from the source PipelineStage transformed by the given `mapper` function.
+   */
+  abstract map(input: O, mapper: (value: T) => T): O;
+
+  /**
+   * Maps each source value to an array of values which is merged in the output PipelineStage.
+   * @param  input  - Input PipelineStage
+   * @param  mapper - Transformation function
+   * @return Output PipelineStage
+   */
+  abstract flatMap(input: O, mapper: (value: T) => T[]): O;
+
+  /**
+   * Projects each source value to a PipelineStage which is merged in the output PipelineStage.
+   * @param  input  - Input PipelineStage
+   * @param  mapper - Transformation function
+   * @return Output PipelineStage
+   */
+  abstract mergeMap(input: O, mapper: (value: T) => O): O;
+
+  /**
+   * Filter items emitted by the source PipelineStage by only emitting those that satisfy a specified predicate.
+   * @param  input     - Input PipelineStage
+   * @param  predicate - Predicate function
+   * @return Output PipelineStage
+   */
+  abstract filter(input: O, predicate: (value: T) => boolean): O;
+
+  /**
+   * Applies an accumulator function over the source PipelineStage, and returns the accumulated result when the source completes, given an optional initial value.
+   * @param  input   - Input PipelineStage
+   * @param  reducer - Accumulator function
+   * @return A PipelineStage that emits a single value that is the result of accumulating the values emitted by the source PipelineStage.
+   */
+  abstract reduce(input: O, reducer: (acc: T, value: T) => T, initial?: T): O;
+
+  /**
+   * Emits only the first `count` values emitted by the source PipelineStage.
+   * @param  input - Input PipelineStage
+   * @param  count - How many items to take
+   * @return A PipelineStage that emits only the first count values emitted by the source PipelineStage, or all of the values from the source if the source emits fewer than count values.
+   */
+  abstract limit(input: O, count: number): O;
+
+  /**
+   * Returns a PipelineStage that skips the first count items emitted by the source PipelineStage.
+   * @param  input  - Input PipelineStage
+   * @param  count  - How many items to skip
+   * @return A PipelineStage that skips values emitted by the source PipelineStage.
+   */
+  abstract skip(input: O, count: number): O;
+
+  /**
+   * Returns a PipelineStage that emits all items emitted by the source PipelineStage that are distinct by comparison from previous items.
+   * @param  input - Input PipelineStage
+   * @return A PipelineStage that emits items from the source PipelineStage with distinct values.
+   */
+  abstract distinct(input: O): O;
+
+  /**
+   * Apply a callback on every item emitted by the source PipelineStage
+   * @param  input - Input PipelineStage
+   * @param  cb    - Callback
+   */
+  abstract forEach(input: O, cb: (value: T) => void): void;
+
+  /**
+   * Emits a given value if the source PipelineStage completes without emitting any next value, otherwise mirrors the source PipelineStage.
+   * @param  input        - Input PipelineStage
+   * @param  defaultValue - The default value used if the source Observable is empty.
+   * @return A PipelineStage that emits either the specified defaultValue if the source PipelineStage emits no items, or the values emitted by the source PipelineStage.
+   */
+  abstract defaultIfEmpty(input: O, defaultValue: T): O;
+
+  /**
+   * Buffers the source PipelineStage values until the size hits the maximum bufferSize given.
+   * @param  input - Input PipelineStage
+   * @param  count - The maximum size of the buffer emitted.
+   * @return A PipelineStage of arrays of buffered values.
+   */
+  abstract bufferCount(input: O, count: number): B;
+
+  /**
+   * Collect all items from the source PipelineStage into an array.
+   * @param  input - Input PipelineStage
+   * @return All values emitted by the source PipelineStage as an array
+   */
+  abstract collect(input: O,): B;
+
+  /**
+   * Emits only the first value (or the first value that meets some condition) emitted by the source PipelineStage.
+   * @param  input - Input PipelineStage
+   * @return A PipelineStage of the first item that matches the condition.
+   */
+  first(input: O): O {
+    return this.limit(input, 1)
+  }
+
+  /**
+   * Returns a PipelineStage that emits the items you specify as arguments after it finishes emitting items emitted by the source PipelineStage.
+   * @param  input  - Input PipelineStage
+   * @param  values - Values to append
+   * @return A PipelineStage that emits the items emitted by the source PipelineStage and then emits the items in the specified PipelineStage.
+   */
+  endWith(input: O, values: T[]): O {
+    return this.merge(input, this.from(values))
+  }
+
+  /**
+   * Perform a side effect for every emission on the source PipelineStage, but return a PipelineStage that is identical to the source.
+   * @param  input - Input PipelineStage
+   * @param  cb    - Callback invoked on each item
+   * @return A PipelineStage identical to the source, but runs the specified PipelineStage or callback(s) for each item.
+   */
+  tap(input: O, cb: (value: T) => void): O {
+    return this.map(input, (value: T) => {
+      cb(value)
+      return value
+    })
+  }
+}

--- a/src/engine/pipeline/pipeline-engine.ts
+++ b/src/engine/pipeline/pipeline-engine.ts
@@ -97,20 +97,22 @@ export abstract class PipelineEngine {
   abstract map<F,T>(input: PipelineStage<F>, mapper: (value: F) => T): PipelineStage<T>;
 
   /**
-   * Maps each source value to an array of values which is merged in the output PipelineStage.
-   * @param  input  - Input PipelineStage
-   * @param  mapper - Transformation function
-   * @return Output PipelineStage
-   */
-  abstract flatMap<F,T>(input: PipelineStage<F>, mapper: (value: F) => T[]): PipelineStage<T>;
-
-  /**
    * Projects each source value to a PipelineStage which is merged in the output PipelineStage.
    * @param  input  - Input PipelineStage
    * @param  mapper - Transformation function
    * @return Output PipelineStage
    */
   abstract mergeMap<F,T>(input: PipelineStage<F>, mapper: (value: F) => PipelineStage<T>): PipelineStage<T>;
+
+  /**
+   * Maps each source value to an array of values which is merged in the output PipelineStage.
+   * @param  input  - Input PipelineStage
+   * @param  mapper - Transformation function
+   * @return Output PipelineStage
+   */
+  flatMap<F,T>(input: PipelineStage<F>, mapper: (value: F) => T[]): PipelineStage<T> {
+    return this.mergeMap(input, (value: F) => this.of(...mapper(value)))
+  }
 
   /**
    * Filter items emitted by the source PipelineStage by only emitting those that satisfy a specified predicate.
@@ -176,9 +178,9 @@ export abstract class PipelineEngine {
   abstract bufferCount<T>(input: PipelineStage<T>, count: number): PipelineStage<T[]>;
 
   /**
-   * Collect all items from the source PipelineStage into an array.
+   * Creates a PipelineStage which collect all items from the source PipelineStage into an array, and then emits this array.
    * @param  input - Input PipelineStage
-   * @return All values emitted by the source PipelineStage as an array
+   * @return A PipelineStage which emits all values emitted by the source PipelineStage as an array
    */
   abstract collect<T>(input: PipelineStage<T>): PipelineStage<T[]>;
 
@@ -195,7 +197,7 @@ export abstract class PipelineEngine {
    * Returns a PipelineStage that emits the items you specify as arguments after it finishes emitting items emitted by the source PipelineStage.
    * @param  input  - Input PipelineStage
    * @param  values - Values to append
-   * @return A PipelineStage that emits the items emitted by the source PipelineStage and then emits the items in the specified PipelineStage.
+   * @return A PipelineStage that emits the items emitted by the source PipelineStage and then emits the additional values.
    */
   endWith<T>(input: PipelineStage<T>, values: T[]): PipelineStage<T> {
     return this.merge(input, this.from(values))

--- a/src/engine/pipeline/pipeline-engine.ts
+++ b/src/engine/pipeline/pipeline-engine.ts
@@ -119,7 +119,7 @@ export abstract class PipelineEngine {
    * @param  reducer - Accumulator function
    * @return A PipelineStage that emits a single value that is the result of accumulating the values emitted by the source PipelineStage.
    */
-  abstract reduce<T>(input: PipelineStage<T>, reducer: (acc: T, value: T) => T, initial?: T): PipelineStage<T>;
+  abstract reduce<F,T>(input: PipelineStage<F>, reducer: (acc: T, value: F) => T, initial?: T): PipelineStage<T>;
 
   /**
    * Emits only the first `count` values emitted by the source PipelineStage.
@@ -152,12 +152,12 @@ export abstract class PipelineEngine {
   abstract forEach<T>(input: PipelineStage<T>, cb: (value: T) => void): void;
 
   /**
-   * Emits a given value if the source PipelineStage completes without emitting any next value, otherwise mirrors the source PipelineStage.
+   * Emits given values if the source PipelineStage completes without emitting any next value, otherwise mirrors the source PipelineStage.
    * @param  input        - Input PipelineStage
-   * @param  defaultValue - The default value used if the source Observable is empty.
-   * @return A PipelineStage that emits either the specified defaultValue if the source PipelineStage emits no items, or the values emitted by the source PipelineStage.
+   * @param  defaultValue - The default values used if the source Observable is empty.
+   * @return A PipelineStage that emits either the specified default values if the source PipelineStage emits no items, or the values emitted by the source PipelineStage.
    */
-  abstract defaultIfEmpty<T>(input: PipelineStage<T>, defaultValue: T): PipelineStage<T>;
+  abstract defaultValues<T>(input: PipelineStage<T>, ...values: T[]): PipelineStage<T>;
 
   /**
    * Buffers the source PipelineStage values until the size hits the maximum bufferSize given.

--- a/src/engine/pipeline/pipeline.ts
+++ b/src/engine/pipeline/pipeline.ts
@@ -1,0 +1,53 @@
+/* file : pipeline.ts
+MIT License
+
+Copyright (c) 2019 Thomas Minier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+'use strict'
+
+import { PipelineEngine, PipelineStage } from './pipeline-engine'
+import RxjsPipeline from './rxjs-pipeline'
+import { Bindings } from '../../rdf/bindings'
+
+// current pipeline engine used for processing bindings
+let _currentEngineBindings: PipelineEngine<Bindings, PipelineStage<Bindings>, PipelineStage<Bindings[]>> = new RxjsPipeline<Bindings>()
+
+/**
+ * Singleton class used to access the current pipeline engine
+ */
+export class BindingsPipeline {
+  /**
+   * Get the instance of the current pipeline engine
+   * @return The instance of the current pipeline engine
+   */
+  static getInstance(): PipelineEngine<Bindings, PipelineStage<Bindings>, PipelineStage<Bindings[]>> {
+    return _currentEngineBindings
+  }
+
+  /**
+   * Set the instance of the current pipeline engine
+   * @param instance  - New pipeline engine to use as the current one
+   */
+  static setInstance(instance: PipelineEngine<Bindings, PipelineStage<Bindings>, PipelineStage<Bindings[]>>): void {
+    _currentEngineBindings = instance
+  }
+}

--- a/src/engine/pipeline/pipeline.ts
+++ b/src/engine/pipeline/pipeline.ts
@@ -32,6 +32,7 @@ let _currentEngine: PipelineEngine = new RxjsPipeline()
 
 /**
  * Singleton class used to access the current pipeline engine
+ * @author Thomas Minier
  */
 export class Pipeline {
   /**

--- a/src/engine/pipeline/pipeline.ts
+++ b/src/engine/pipeline/pipeline.ts
@@ -24,30 +24,29 @@ SOFTWARE.
 
 'use strict'
 
-import { PipelineEngine, PipelineStage } from './pipeline-engine'
+import { PipelineEngine } from './pipeline-engine'
 import RxjsPipeline from './rxjs-pipeline'
-import { Bindings } from '../../rdf/bindings'
 
 // current pipeline engine used for processing bindings
-let _currentEngineBindings: PipelineEngine<Bindings, PipelineStage<Bindings>, PipelineStage<Bindings[]>> = new RxjsPipeline<Bindings>()
+let _currentEngine: PipelineEngine = new RxjsPipeline()
 
 /**
  * Singleton class used to access the current pipeline engine
  */
-export class BindingsPipeline {
+export class Pipeline {
   /**
    * Get the instance of the current pipeline engine
    * @return The instance of the current pipeline engine
    */
-  static getInstance(): PipelineEngine<Bindings, PipelineStage<Bindings>, PipelineStage<Bindings[]>> {
-    return _currentEngineBindings
+  static getInstance(): PipelineEngine {
+    return _currentEngine
   }
 
   /**
    * Set the instance of the current pipeline engine
    * @param instance  - New pipeline engine to use as the current one
    */
-  static setInstance(instance: PipelineEngine<Bindings, PipelineStage<Bindings>, PipelineStage<Bindings[]>>): void {
-    _currentEngineBindings = instance
+  static setInstance(instance: PipelineEngine): void {
+    _currentEngine = instance
   }
 }

--- a/src/engine/pipeline/rxjs-pipeline.ts
+++ b/src/engine/pipeline/rxjs-pipeline.ts
@@ -1,0 +1,127 @@
+/* file : rxjs-pipeline.ts
+MIT License
+
+Copyright (c) 2019 Thomas Minier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+'use strict'
+
+import { Observable, ObservableInput, empty, from, of, merge } from 'rxjs'
+import {
+  bufferCount,
+  defaultIfEmpty,
+  distinct,
+  endWith,
+  filter,
+  first,
+  flatMap,
+  take,
+  skip,
+  map,
+  mergeMap,
+  tap,
+  toArray,
+  reduce
+} from 'rxjs/operators'
+import { PipelineEngine } from './pipeline-engine'
+
+/**
+ * A pipeline implemented using Rx.js
+ * @author Thomas Minier
+ */
+export default class RxjsPipeline<T> extends PipelineEngine<T, Observable<T>, Observable<T[]>> {
+
+  empty(): Observable<T> {
+    return empty()
+  }
+
+  of(...values: T[]): Observable<T> {
+    return of(...values)
+  }
+
+  from(x: ObservableInput<T>): Observable<T> {
+    return from(x)
+  }
+
+  merge (...inputs: Observable<T>[]): Observable<T> {
+    return merge(...inputs)
+  }
+
+  map(input: Observable<T>, mapper: (value: T) => T): Observable<T> {
+    return input.pipe(map(mapper))
+  }
+
+  flatMap(input: Observable<T>, mapper: (value: T) => T[]): Observable<T> {
+    return input.pipe(flatMap(mapper))
+  }
+
+  mergeMap(input: Observable<T>, mapper: (value: T) => Observable<T>): Observable<T> {
+    return input.pipe(mergeMap(mapper))
+  }
+
+  filter(input: Observable<T>, predicate: (value: T) => boolean): Observable<T> {
+    return input.pipe(filter(predicate))
+  }
+
+  reduce(input: Observable<T>, reducer: (acc: T, value: T) => T, initial?: T): Observable<T> {
+    return input.pipe(reduce(reducer, initial))
+  }
+
+  limit(input: Observable<T>, stopAfter: number): Observable<T> {
+    return input.pipe(take(stopAfter))
+  }
+
+  skip(input: Observable<T>, toSkip: number): Observable<T> {
+    return input.pipe(skip(toSkip))
+  }
+
+  distinct(input: Observable<T>): Observable<T> {
+    return input.pipe(distinct())
+  }
+
+  defaultIfEmpty(input: Observable<T>, defaultValue: T): Observable<T> {
+    return input.pipe(defaultIfEmpty(defaultValue))
+  }
+
+  bufferCount(input: Observable<T>, count: number): Observable<T[]> {
+    return input.pipe(bufferCount(count))
+  }
+
+  forEach(input: Observable<T>, cb: (value: T) => void): void {
+    input.forEach(cb)
+  }
+
+  first(input: Observable<T>): Observable<T> {
+    return input.pipe(first())
+  }
+
+  endWith(input: Observable<T>, values: T[]): Observable<T> {
+    return input.pipe(endWith(...values))
+  }
+
+  tap(input: Observable<T>, cb: (value: T) => void): Observable<T> {
+    return input.pipe(tap(cb))
+  }
+
+  collect(input: Observable<T>): Observable<T[]> {
+    return input.pipe(toArray())
+  }
+}

--- a/src/engine/pipeline/rxjs-pipeline.ts
+++ b/src/engine/pipeline/rxjs-pipeline.ts
@@ -42,7 +42,7 @@ import {
   shareReplay,
   reduce
 } from 'rxjs/operators'
-import { PipelineEngine } from './pipeline-engine'
+import { PipelineInput, PipelineEngine } from './pipeline-engine'
 
 /**
  * A pipeline implemented using Rx.js
@@ -58,7 +58,7 @@ export default class RxjsPipeline extends PipelineEngine {
     return of(...values)
   }
 
-  from<T>(x: ObservableInput<T>): Observable<T> {
+  from<T>(x: any): Observable<T> {
     return from(x)
   }
 
@@ -66,7 +66,7 @@ export default class RxjsPipeline extends PipelineEngine {
     return stage.pipe(shareReplay(5))
   }
 
-  merge<T>(...inputs: Observable<T>[]): Observable<T> {
+  merge<T>(...inputs: Array<Observable<T>>): Observable<T> {
     return concat(...inputs)
   }
 

--- a/src/engine/pipeline/rxjs-pipeline.ts
+++ b/src/engine/pipeline/rxjs-pipeline.ts
@@ -39,6 +39,7 @@ import {
   mergeMap,
   tap,
   toArray,
+  share,
   reduce
 } from 'rxjs/operators'
 import { PipelineEngine } from './pipeline-engine'
@@ -59,6 +60,10 @@ export default class RxjsPipeline extends PipelineEngine {
 
   from<T>(x: ObservableInput<T>): Observable<T> {
     return from(x)
+  }
+
+  clone<T>(stage: Observable<T>): Observable<T> {
+    return stage.pipe(share())
   }
 
   merge<T>(...inputs: Observable<T>[]): Observable<T> {

--- a/src/engine/pipeline/rxjs-pipeline.ts
+++ b/src/engine/pipeline/rxjs-pipeline.ts
@@ -24,7 +24,7 @@ SOFTWARE.
 
 'use strict'
 
-import { Observable, ObservableInput, empty, from, of, merge } from 'rxjs'
+import { Observable, ObservableInput, empty, from, of, concat } from 'rxjs'
 import {
   bufferCount,
   defaultIfEmpty,
@@ -62,7 +62,7 @@ export default class RxjsPipeline extends PipelineEngine {
   }
 
   merge<T>(...inputs: Observable<T>[]): Observable<T> {
-    return merge(...inputs)
+    return concat(...inputs)
   }
 
   map<F,T>(input: Observable<F>, mapper: (value: F) => T): Observable<T> {
@@ -93,8 +93,8 @@ export default class RxjsPipeline extends PipelineEngine {
     return input.pipe(skip(toSkip))
   }
 
-  distinct<T>(input: Observable<T>): Observable<T> {
-    return input.pipe(distinct())
+  distinct<T, K>(input: Observable<T>, selector?: (value: T) => K): Observable<T> {
+    return input.pipe(distinct(selector))
   }
 
   defaultValues<T>(input: Observable<T>, ...values: T[]): Observable<T> {

--- a/src/engine/pipeline/rxjs-pipeline.ts
+++ b/src/engine/pipeline/rxjs-pipeline.ts
@@ -49,7 +49,7 @@ import { PipelineEngine } from './pipeline-engine'
  */
 export default class RxjsPipeline extends PipelineEngine {
 
-  empty(): Observable<void> {
+  empty<T>(): Observable<T> {
     return empty()
   }
 

--- a/src/engine/pipeline/rxjs-pipeline.ts
+++ b/src/engine/pipeline/rxjs-pipeline.ts
@@ -39,7 +39,7 @@ import {
   mergeMap,
   tap,
   toArray,
-  share,
+  shareReplay,
   reduce
 } from 'rxjs/operators'
 import { PipelineEngine } from './pipeline-engine'
@@ -63,7 +63,7 @@ export default class RxjsPipeline extends PipelineEngine {
   }
 
   clone<T>(stage: Observable<T>): Observable<T> {
-    return stage.pipe(share())
+    return stage.pipe(shareReplay(5))
   }
 
   merge<T>(...inputs: Observable<T>[]): Observable<T> {

--- a/src/engine/pipeline/rxjs-pipeline.ts
+++ b/src/engine/pipeline/rxjs-pipeline.ts
@@ -47,81 +47,81 @@ import { PipelineEngine } from './pipeline-engine'
  * A pipeline implemented using Rx.js
  * @author Thomas Minier
  */
-export default class RxjsPipeline<T> extends PipelineEngine<T, Observable<T>, Observable<T[]>> {
+export default class RxjsPipeline extends PipelineEngine {
 
-  empty(): Observable<T> {
+  empty(): Observable<void> {
     return empty()
   }
 
-  of(...values: T[]): Observable<T> {
+  of<T>(...values: T[]): Observable<T> {
     return of(...values)
   }
 
-  from(x: ObservableInput<T>): Observable<T> {
+  from<T>(x: ObservableInput<T>): Observable<T> {
     return from(x)
   }
 
-  merge (...inputs: Observable<T>[]): Observable<T> {
+  merge<T>(...inputs: Observable<T>[]): Observable<T> {
     return merge(...inputs)
   }
 
-  map(input: Observable<T>, mapper: (value: T) => T): Observable<T> {
+  map<F,T>(input: Observable<F>, mapper: (value: F) => T): Observable<T> {
     return input.pipe(map(mapper))
   }
 
-  flatMap(input: Observable<T>, mapper: (value: T) => T[]): Observable<T> {
+  flatMap<F,T>(input: Observable<F>, mapper: (value: F) => T[]): Observable<T> {
     return input.pipe(flatMap(mapper))
   }
 
-  mergeMap(input: Observable<T>, mapper: (value: T) => Observable<T>): Observable<T> {
+  mergeMap<F,T>(input: Observable<F>, mapper: (value: F) => Observable<T>): Observable<T> {
     return input.pipe(mergeMap(mapper))
   }
 
-  filter(input: Observable<T>, predicate: (value: T) => boolean): Observable<T> {
+  filter<T>(input: Observable<T>, predicate: (value: T) => boolean): Observable<T> {
     return input.pipe(filter(predicate))
   }
 
-  reduce(input: Observable<T>, reducer: (acc: T, value: T) => T, initial?: T): Observable<T> {
+  reduce<T>(input: Observable<T>, reducer: (acc: T, value: T) => T, initial?: T): Observable<T> {
     return input.pipe(reduce(reducer, initial))
   }
 
-  limit(input: Observable<T>, stopAfter: number): Observable<T> {
+  limit<T>(input: Observable<T>, stopAfter: number): Observable<T> {
     return input.pipe(take(stopAfter))
   }
 
-  skip(input: Observable<T>, toSkip: number): Observable<T> {
+  skip<T>(input: Observable<T>, toSkip: number): Observable<T> {
     return input.pipe(skip(toSkip))
   }
 
-  distinct(input: Observable<T>): Observable<T> {
+  distinct<T>(input: Observable<T>): Observable<T> {
     return input.pipe(distinct())
   }
 
-  defaultIfEmpty(input: Observable<T>, defaultValue: T): Observable<T> {
+  defaultIfEmpty<T>(input: Observable<T>, defaultValue: T): Observable<T> {
     return input.pipe(defaultIfEmpty(defaultValue))
   }
 
-  bufferCount(input: Observable<T>, count: number): Observable<T[]> {
+  bufferCount<T>(input: Observable<T>, count: number): Observable<T[]> {
     return input.pipe(bufferCount(count))
   }
 
-  forEach(input: Observable<T>, cb: (value: T) => void): void {
+  forEach<T>(input: Observable<T>, cb: (value: T) => void): void {
     input.forEach(cb)
   }
 
-  first(input: Observable<T>): Observable<T> {
+  first<T>(input: Observable<T>): Observable<T> {
     return input.pipe(first())
   }
 
-  endWith(input: Observable<T>, values: T[]): Observable<T> {
+  endWith<T>(input: Observable<T>, values: T[]): Observable<T> {
     return input.pipe(endWith(...values))
   }
 
-  tap(input: Observable<T>, cb: (value: T) => void): Observable<T> {
+  tap<T>(input: Observable<T>, cb: (value: T) => void): Observable<T> {
     return input.pipe(tap(cb))
   }
 
-  collect(input: Observable<T>): Observable<T[]> {
+  collect<T>(input: Observable<T>): Observable<T[]> {
     return input.pipe(toArray())
   }
 }

--- a/src/engine/pipeline/vector-pipeline.ts
+++ b/src/engine/pipeline/vector-pipeline.ts
@@ -1,0 +1,178 @@
+/* file : vector-pipeline.ts
+MIT License
+
+Copyright (c) 2019 Thomas Minier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+'use strict'
+
+import { PipelineInput, PipelineStage, PipelineEngine } from './pipeline-engine'
+import { chunk, flatMap, flatten, isUndefined, slice, uniq, uniqBy } from 'lodash'
+
+/**
+ * A PipelineStage which materializes all intermediate results in main memory.
+ * @author Thomas Minier
+ */
+export class VectorStage<T> implements PipelineStage<T> {
+  // We need to use Promise to store the stage content,
+  // as some computations can require asynchronous computations.
+  // For example, the RDF graph can send HTTP requests to evaluate triple patterns.
+  private readonly _content: Promise<Array<T>>
+
+  constructor(content: Promise<Array<T>>) {
+    this._content = content
+  }
+
+  getContent(): Promise<Array<T>> {
+    return this._content
+  }
+
+  subscribe(onData: (value: T) => void, onError: (err: any) => void, onEnd: () => void): void {
+    try {
+      this._content
+        .then(c => {
+          c.forEach(onData)
+          onEnd()
+        })
+        .catch(onError)
+    } catch (e) {
+      onError(e)
+    }
+  }
+
+  forEach(cb: (value: T) => void): void {
+    this._content
+      .then(c => {
+        c.forEach(cb)
+      })
+  }
+}
+
+/**
+ * A pipeline implemented using {@link VectorStage}, *i.e.*, all intermediate results are materialized in main memory. This approach is often called **vectorized approach**.
+ * This pipeline is more efficient CPU-wise than {@link RxjsPipeline}, but it also consumes much more memory, as it materializes evey stage of the pipeline before moving to the next.
+ * It should only be used when SPARQL queries generate few intermediate results.
+ * @see P. A. Boncz, S. Manegold, and M. L. Kersten. "Database architecture evolution: Mammals flourished long before dinosaurs became extinct". PVLDB, (2009)
+ * @author Thomas Minier
+ */
+export default class VectorPipeline extends PipelineEngine {
+
+  empty<T>(): VectorStage<T> {
+    return new VectorStage<T>(Promise.resolve([]))
+  }
+
+  of<T>(...values: T[]): VectorStage<T> {
+    return new VectorStage<T>(Promise.resolve(values))
+  }
+
+  from<T>(x: PipelineInput<T>): VectorStage<T> {
+    if ((x as VectorStage<T>).getContent !== undefined) {
+      return new VectorStage<T>((x as VectorStage<T>).getContent())
+    } else if (Array.isArray(x)) {
+      return new VectorStage<T>(Promise.resolve(x))
+    } else if ((x as Promise<T>).then !== undefined) {
+      return new VectorStage<T>((x as Promise<T>).then(v => [v]))
+    } else if (Symbol.iterator in x) {
+      return new VectorStage<T>(Promise.resolve(Array.from(x as Iterable<T>)))
+    }
+    throw new Error('Invalid argument for VectorPipeline.from: ' + x)
+  }
+
+  clone<T>(stage: VectorStage<T>): VectorStage<T> {
+    return new VectorStage<T>(stage.getContent().then(c => c.slice(0)))
+  }
+
+  merge<T>(...inputs: Array<VectorStage<T>>): VectorStage<T> {
+    return new VectorStage<T>(Promise.all(inputs.map(i => i.getContent())).then((contents: T[][]) => {
+      return flatten(contents)
+    }))
+  }
+
+  map<F,T>(input: VectorStage<F>, mapper: (value: F) => T): VectorStage<T> {
+    return new VectorStage<T>(input.getContent().then(c => c.map(mapper)))
+  }
+
+  flatMap<F,T>(input: VectorStage<F>, mapper: (value: F) => T[]): VectorStage<T> {
+    return new VectorStage<T>(input.getContent().then(c => flatMap(c, mapper)))
+  }
+
+  mergeMap<F,T>(input: VectorStage<F>, mapper: (value: F) => VectorStage<T>): VectorStage<T> {
+    return new VectorStage<T>(input.getContent().then(content => {
+      const stages: VectorStage<T>[] = content.map(value => mapper(value))
+      return Promise.all(stages.map(s => s.getContent())).then((contents: T[][]) => {
+        return flatten(contents)
+      })
+    }))
+  }
+
+  filter<T>(input: VectorStage<T>, predicate: (value: T) => boolean): VectorStage<T> {
+    return new VectorStage<T>(input.getContent().then(c => c.filter(predicate)))
+  }
+
+  reduce<F,T>(input: VectorStage<F>, reducer: (acc: T, value: F) => T, initial: T): VectorStage<T> {
+    return new VectorStage<T>(input.getContent().then(c => [c.reduce(reducer, initial)]))
+  }
+
+  limit<T>(input: VectorStage<T>, stopAfter: number): VectorStage<T> {
+    return new VectorStage<T>(input.getContent().then(c => slice(c, 0, stopAfter)))
+  }
+
+  skip<T>(input: VectorStage<T>, toSkip: number): VectorStage<T> {
+    return new VectorStage<T>(input.getContent().then(c => slice(c, toSkip)))
+  }
+
+  distinct<T, K>(input: VectorStage<T>, selector?: (value: T) => K): VectorStage<T> {
+    if (isUndefined(selector)) {
+      return new VectorStage<T>(input.getContent().then(c => uniq(c)))
+    }
+    return new VectorStage<T>(input.getContent().then(c => uniqBy(c, selector)))
+  }
+
+  defaultValues<T>(input: VectorStage<T>, ...values: T[]): VectorStage<T> {
+    return new VectorStage<T>(input.getContent().then(content => {
+      if (content.length > 0) {
+        return content.slice(0)
+      }
+      return values
+    }))
+  }
+
+  bufferCount<T>(input: VectorStage<T>, count: number): VectorStage<T[]> {
+    return new VectorStage<T[]>(input.getContent().then(c => chunk(c, count)))
+  }
+
+  forEach<T>(input: VectorStage<T>, cb: (value: T) => void): void {
+    input.forEach(cb)
+  }
+
+  first<T>(input: VectorStage<T>): VectorStage<T> {
+    return new VectorStage<T>(input.getContent().then(content => {
+      if (content.length < 1) {
+        return []
+      }
+      return [content[0]]
+    }))
+  }
+
+  collect<T>(input: VectorStage<T>): VectorStage<T[]> {
+    return new VectorStage<T[]>(input.getContent().then(c => [c]))
+  }
+}

--- a/src/engine/plan-builder.ts
+++ b/src/engine/plan-builder.ts
@@ -274,7 +274,7 @@ export default class PlanBuilder {
     // Handles transformers
     if (aggregates.length > 0) {
       graphIterator = aggregates.reduce((obs: Observable<Bindings>, agg: Algebra.Aggregation) => {
-        return obs.pipe(bind(agg.variable, agg.expression, this._customFunctions))
+        return bind(obs, agg.variable, agg.expression, this._customFunctions)
       }, graphIterator)
     }
 
@@ -423,7 +423,7 @@ export default class PlanBuilder {
         }
       case 'bind':
         const bindNode = group as Algebra.BindNode
-        return source.pipe(bind(bindNode.variable, bindNode.expression, this._customFunctions))
+        return bind(source, bindNode.variable, bindNode.expression, this._customFunctions)
       default:
         throw new Error(`Unsupported SPARQL group pattern found in query: ${group.type}`)
     }

--- a/src/engine/plan-builder.ts
+++ b/src/engine/plan-builder.ts
@@ -26,9 +26,10 @@ SOFTWARE.
 
 // General libraries
 import { Algebra, Parser } from 'sparqljs'
-import { Observable, of, merge } from 'rxjs'
-import { map, take, skip } from 'rxjs/operators'
 import { Consumable } from '../operators/update/consumer'
+// pipelining engine
+import { Pipeline } from '../engine/pipeline/pipeline'
+import { PipelineStage } from '../engine/pipeline/pipeline-engine'
 // RDF core classes
 import { terms } from '../rdf-terms'
 import { Bindings, BindingBase } from '../rdf/bindings'
@@ -189,7 +190,7 @@ export default class PlanBuilder {
    * @param  options  - Execution options
    * @return An iterator that can be consumed to evaluate the query.
    */
-  build (query: any, context?: ExecutionContext): Observable<QueryOutput> | Consumable {
+  build (query: any, context?: ExecutionContext): PipelineStage<QueryOutput> | Consumable {
     // If needed, parse the string query into a logical query execution plan
     if (typeof query === 'string') {
       query = this._parser.parse(query)
@@ -214,10 +215,11 @@ export default class PlanBuilder {
    * @param  source - Source iterator
    * @return An iterator that can be consumed to evaluate the query.
    */
-  _buildQueryPlan (query: Algebra.RootNode, context: ExecutionContext, source?: Observable<Bindings>): Observable<Bindings> {
+  _buildQueryPlan (query: Algebra.RootNode, context: ExecutionContext, source?: PipelineStage<Bindings>): PipelineStage<Bindings> {
+    const engine = Pipeline.getInstance()
     if (isNull(source) || isUndefined(source)) {
       // build pipeline starting iterator
-      source = of(new BindingBase())
+      source = engine.of(new BindingBase())
     }
     context.setProperty('prefixes', query.prefixes)
 
@@ -253,11 +255,11 @@ export default class PlanBuilder {
     }
 
     // Handles WHERE clause
-    let graphIterator: Observable<Bindings>
+    let graphIterator: PipelineStage<Bindings>
     if (query.where != null && query.where.length > 0) {
       graphIterator = this._buildWhere(source, query.where, context)
     } else {
-      graphIterator = of(new BindingBase())
+      graphIterator = engine.of(new BindingBase())
     }
 
     // Parse query variable to separate projection & aggregate variables
@@ -273,7 +275,7 @@ export default class PlanBuilder {
 
     // Handles transformers
     if (aggregates.length > 0) {
-      graphIterator = aggregates.reduce((obs: Observable<Bindings>, agg: Algebra.Aggregation) => {
+      graphIterator = aggregates.reduce((obs: PipelineStage<Bindings>, agg: Algebra.Aggregation) => {
         return bind(obs, agg.variable, agg.expression, this._customFunctions)
       }, graphIterator)
     }
@@ -290,15 +292,15 @@ export default class PlanBuilder {
 
     // Create iterators for modifiers
     if (query.distinct) {
-      graphIterator = graphIterator.pipe(sparqlDistinct())
+      graphIterator = sparqlDistinct(graphIterator)
     }
 
     // Add offsets and limits if requested
     if ('offset' in query) {
-      graphIterator = graphIterator.pipe(skip(query.offset!))
+      graphIterator = engine.skip(graphIterator, query.offset!)
     }
     if ('limit' in query) {
-      graphIterator = graphIterator.pipe(take(query.limit!))
+      graphIterator = engine.limit(graphIterator, query.limit!)
     }
     // graphIterator.queryType = query.queryType
     return graphIterator
@@ -311,7 +313,7 @@ export default class PlanBuilder {
    * @param  options  - Execution options
    * @return An iterator used to evaluate the WHERE clause
    */
-  _buildWhere (source: Observable<Bindings>, groups: Algebra.PlanNode[], context: ExecutionContext): Observable<Bindings> {
+  _buildWhere (source: PipelineStage<Bindings>, groups: Algebra.PlanNode[], context: ExecutionContext): PipelineStage<Bindings> {
     groups = sortBy(groups, g => {
       switch (g.type) {
         case 'bgp':
@@ -357,7 +359,8 @@ export default class PlanBuilder {
    * @param  options - Execution options
    * @return An iterator used to evaluate the SPARQL Group
    */
-  _buildGroup (source: Observable<Bindings>, group: Algebra.PlanNode, context: ExecutionContext): Observable<Bindings> {
+  _buildGroup (source: PipelineStage<Bindings>, group: Algebra.PlanNode, context: ExecutionContext): PipelineStage<Bindings> {
+    const engine = Pipeline.getInstance()
     // Reset flags on the options for child iterators
     let childContext = context.clone()
 
@@ -380,9 +383,9 @@ export default class PlanBuilder {
 
         // filter out variables added by the rewriting of property paths
         if (tempVariables.length > 0) {
-          iter = iter.pipe(map(bindings => {
+          iter = engine.map(iter, bindings => {
             return bindings.filter(v => tempVariables.indexOf(v) == -1)
-          }))
+          })
         }
         return iter
       case 'query':
@@ -404,11 +407,11 @@ export default class PlanBuilder {
       case 'optional':
         return optional(source, (group as Algebra.GroupNode).patterns, this, childContext)
       case 'union':
-        return merge(...(group as Algebra.GroupNode).patterns.map(patternToken => {
+        return engine.merge(...(group as Algebra.GroupNode).patterns.map(patternToken => {
           return this._buildGroup(source, patternToken, childContext)
         }))
       case 'minus':
-        const rightSource = this._buildWhere(of(new BindingBase()), (group as Algebra.GroupNode).patterns, childContext)
+        const rightSource = this._buildWhere(engine.of(new BindingBase()), (group as Algebra.GroupNode).patterns, childContext)
         return minus(source, rightSource)
       case 'filter':
         const filter = group as Algebra.FilterNode
@@ -419,7 +422,7 @@ export default class PlanBuilder {
           case 'notexists':
             return exists(source, filter.expression.args, this, true, childContext)
           default:
-            return source.pipe(sparqlFilter(filter.expression, this._customFunctions))
+            return sparqlFilter(source, filter.expression, this._customFunctions)
         }
       case 'bind':
         const bindNode = group as Algebra.BindNode
@@ -438,7 +441,7 @@ export default class PlanBuilder {
    * @param options - Execution options
    * @return An iterator which evaluates a SPARQL query with VALUES clause(s)
    */
-  _buildValues (source: Observable<Bindings>, groups: Algebra.PlanNode[], context: ExecutionContext): Observable<Bindings> {
+  _buildValues (source: PipelineStage<Bindings>, groups: Algebra.PlanNode[], context: ExecutionContext): PipelineStage<Bindings> {
     let [ values, others ] = partition(groups, g => g.type === 'values')
     const bindingsLists = values.map(g => (g as Algebra.ValuesNode).values)
     // for each VALUES clause
@@ -450,11 +453,11 @@ export default class PlanBuilder {
         const temp = others.map(g => deepApplyBindings(g, bindings))
         return extendByBindings(this._buildWhere(source, temp, context), bindings)
       })
-      return merge(...unionBranches)
+      return Pipeline.getInstance().merge(...unionBranches)
     })
     // Users may use more than one VALUES clause
     if (iterators.length > 1) {
-      return merge(...iterators)
+      return Pipeline.getInstance().merge(...iterators)
     }
     return iterators[0]
   }

--- a/src/engine/plan-builder.ts
+++ b/src/engine/plan-builder.ts
@@ -185,10 +185,10 @@ export default class PlanBuilder {
 
   /**
    * Build the physical query execution of a SPARQL 1.1 query
-   * and returns an iterator that can be consumed to evaluate the query.
+   * and returns a {@link PipelineStage} or a {@link Consumable} that can be consumed to evaluate the query.
    * @param  query        - SPARQL query to evaluated
    * @param  options  - Execution options
-   * @return An iterator that can be consumed to evaluate the query.
+   * @return A {@link PipelineStage} or a {@link Consumable} that can be consumed to evaluate the query.
    */
   build (query: any, context?: ExecutionContext): PipelineStage<QueryOutput> | Consumable {
     // If needed, parse the string query into a logical query execution plan
@@ -210,10 +210,10 @@ export default class PlanBuilder {
 
   /**
    * Build the physical query execution of a SPARQL query
-   * @param  query         - Parsed SPARQL query
+   * @param  query    - Parsed SPARQL query
    * @param  options  - Execution options
-   * @param  source - Source iterator
-   * @return An iterator that can be consumed to evaluate the query.
+   * @param  source   - Input {@link PipelineStage}
+   * @return A {@link PipelineStage} that can be consumed to evaluate the query.
    */
   _buildQueryPlan (query: Algebra.RootNode, context: ExecutionContext, source?: PipelineStage<Bindings>): PipelineStage<Bindings> {
     const engine = Pipeline.getInstance()
@@ -308,10 +308,10 @@ export default class PlanBuilder {
 
   /**
    * Optimize a WHERE clause and build the corresponding physical plan
-   * @param  source  - Source iterator
+   * @param  source  - Input {@link PipelineStage}
    * @param  groups   - WHERE clause to process
    * @param  options  - Execution options
-   * @return An iterator used to evaluate the WHERE clause
+   * @return A {@link PipelineStage} used to evaluate the WHERE clause
    */
   _buildWhere (source: PipelineStage<Bindings>, groups: Algebra.PlanNode[], context: ExecutionContext): PipelineStage<Bindings> {
     groups = sortBy(groups, g => {
@@ -354,10 +354,10 @@ export default class PlanBuilder {
 
   /**
    * Build a physical plan for a SPARQL group clause
-   * @param  source  - Source iterator
+   * @param  source  - Input {@link PipelineStage}
    * @param  group   - SPARQL Group
    * @param  options - Execution options
-   * @return An iterator used to evaluate the SPARQL Group
+   * @return A {@link PipelineStage} used to evaluate the SPARQL Group
    */
   _buildGroup (source: PipelineStage<Bindings>, group: Algebra.PlanNode, context: ExecutionContext): PipelineStage<Bindings> {
     const engine = Pipeline.getInstance()
@@ -433,13 +433,13 @@ export default class PlanBuilder {
   }
 
   /**
-   * Build an iterator which evaluates a SPARQL query with VALUES clause(s).
+   * Build a {@link PipelineStage} which evaluates a SPARQL query with VALUES clause(s).
    * It rely on a query rewritiing approach:
    * ?s ?p ?o . VALUES ?s { :1 :2 } becomes {:1 ?p ?o BIND(:1 AS ?s)} UNION {:2 ?p ?o BIND(:2 AS ?s)}
-   * @param source  - Source iterator
+   * @param source  - Input {@link PipelineStage}
    * @param groups  - Query body, i.e., WHERE clause
    * @param options - Execution options
-   * @return An iterator which evaluates a SPARQL query with VALUES clause(s)
+   * @return A {@link PipelineStage} which evaluates a SPARQL query with VALUES clause(s)
    */
   _buildValues (source: PipelineStage<Bindings>, groups: Algebra.PlanNode[], context: ExecutionContext): PipelineStage<Bindings> {
     let [ values, others ] = partition(groups, g => g.type === 'values')

--- a/src/operators/bind.ts
+++ b/src/operators/bind.ts
@@ -24,8 +24,8 @@ SOFTWARE.
 
 'use strict'
 
-import { Observable } from 'rxjs'
-import { map } from 'rxjs/operators'
+import { Pipeline } from '../engine/pipeline/pipeline'
+import { PipelineStage } from '../engine/pipeline/pipeline-engine'
 import SPARQLExpression from './expressions/sparql-expression'
 import { Algebra } from 'sparqljs'
 import { Bindings } from '../rdf/bindings'
@@ -41,9 +41,9 @@ import { CustomFunctions } from '../engine/plan-builder'
  * @param expression - SPARQL expression
  * @return A Bind operator
  */
-export default function bind (source: Observable<Bindings>, variable: string, expression: Algebra.Expression | string, customFunctions?: CustomFunctions) {
+export default function bind (source: PipelineStage<Bindings>, variable: string, expression: Algebra.Expression | string, customFunctions?: CustomFunctions): PipelineStage<Bindings> {
   const expr = new SPARQLExpression(expression, customFunctions)
-  return source.pipe(map(bindings => {
+  return Pipeline.getInstance().map(source, bindings => {
     const res = bindings.clone()
     try {
       const value: any = expr.evaluate(bindings)
@@ -52,5 +52,5 @@ export default function bind (source: Observable<Bindings>, variable: string, ex
       }
     } catch (e) {}
     return res
-  }))
+  })
 }

--- a/src/operators/bind.ts
+++ b/src/operators/bind.ts
@@ -36,10 +36,10 @@ import { CustomFunctions } from '../engine/plan-builder'
  * @see {@link https://www.w3.org/TR/sparql11-query/#bind}
  * @author Thomas Minier
  * @author Corentin Marionneau
- * @param source - Source observable
+ * @param source - Source {@link PipelineStage}
  * @param variable  - SPARQL variable used to bind results
  * @param expression - SPARQL expression
- * @return A Bind operator
+ * @return A {@link PipelineStage} which evaluate the BIND operation
  */
 export default function bind (source: PipelineStage<Bindings>, variable: string, expression: Algebra.Expression | string, customFunctions?: CustomFunctions): PipelineStage<Bindings> {
   const expr = new SPARQLExpression(expression, customFunctions)

--- a/src/operators/exists.ts
+++ b/src/operators/exists.ts
@@ -24,8 +24,8 @@ SOFTWARE.
 
 'use strict'
 
-import { Observable, of } from 'rxjs'
-import { first, map, mergeMap, defaultIfEmpty, filter } from 'rxjs/operators'
+import { Pipeline } from '../engine/pipeline/pipeline'
+import { PipelineStage } from '../engine/pipeline/pipeline-engine'
 import { Bindings, BindingBase } from '../rdf/bindings'
 import PlanBuilder from '../engine/plan-builder'
 import ExecutionContext from '../engine/context/execution-context'
@@ -45,24 +45,24 @@ interface ConditionalBindings {
  * @author Thomas Minier
  * TODO this function could be simplified using a filterMap like operator, we should check if Rxjs offers that filterMap
  */
-export default function exists (source: Observable<Bindings>, groups: any[], builder: PlanBuilder, notexists: boolean, context: ExecutionContext) {
+export default function exists (source: PipelineStage<Bindings>, groups: any[], builder: PlanBuilder, notexists: boolean, context: ExecutionContext) {
   const defaultValue: Bindings = new BindingBase()
   defaultValue.setProperty('exists', false)
-  return source
-    .pipe(mergeMap((bindings: Bindings) => {
-      return builder._buildWhere(of(bindings), groups, context)
-        .pipe(defaultIfEmpty(defaultValue))
-        .pipe(first())
-        .pipe(map((b: Bindings) => {
-          const exists: boolean = (!b.hasProperty('exists')) || b.getProperty('exists')
-          return {
-            bindings,
-            output: (exists && (!notexists)) || ((!exists) && notexists)
-          }
-        }))
-    }))
-    .pipe(filter((b: ConditionalBindings) => {
-      return b.output
-    }))
-    .pipe(map((b: ConditionalBindings) => b.bindings))
+  const engine = Pipeline.getInstance()
+  let evaluator = engine.mergeMap(source, (bindings: Bindings) => {
+    let op = builder._buildWhere(engine.of(bindings), groups, context)
+    op = engine.defaultValues(op, defaultValue)
+    op = engine.first(op)
+    return engine.map(op, (b: Bindings) => {
+      const exists: boolean = (!b.hasProperty('exists')) || b.getProperty('exists')
+      return {
+        bindings,
+        output: (exists && (!notexists)) || ((!exists) && notexists)
+      }
+    })
+  })
+  evaluator = engine.filter(evaluator, (b: ConditionalBindings) => {
+    return b.output
+  })
+  return engine.map(evaluator, (b: ConditionalBindings) => b.bindings)
 }

--- a/src/operators/exists.ts
+++ b/src/operators/exists.ts
@@ -37,13 +37,14 @@ interface ConditionalBindings {
 
 /**
  * Evaluates a SPARQL FILTER (NOT) EXISTS clause
- * @param source - Source observable
+ * TODO this function could be simplified using a filterMap like operator, we should check if Rxjs offers that filterMap
+ * @author Thomas Minier
+ * @param source    - Source {@link PipelineStage}
  * @param groups    - Content of the FILTER clause
  * @param builder   - Plan builder used to evaluate subqueries
  * @param notexists - True if the filter is NOT EXISTS, False otherwise
- * @param options   - Execution options
- * @author Thomas Minier
- * TODO this function could be simplified using a filterMap like operator, we should check if Rxjs offers that filterMap
+ * @param context   - Execution context
+ * @return A {@link PipelineStage} which evaluate the FILTER (NOT) EXISTS operation
  */
 export default function exists (source: PipelineStage<Bindings>, groups: any[], builder: PlanBuilder, notexists: boolean, context: ExecutionContext) {
   const defaultValue: Bindings = new BindingBase()

--- a/src/operators/join/bound-join.ts
+++ b/src/operators/join/bound-join.ts
@@ -1,189 +1,196 @@
-/* file : bound-join.ts
-MIT License
-
-Copyright (c) 2018 Thomas Minier
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-*/
-
-import { Observable, from } from 'rxjs'
-import { bufferCount, map } from 'rxjs/operators'
-import Graph from '../../rdf/graph'
-import { Bindings } from '../../rdf/bindings'
-import { Algebra } from 'sparqljs'
-import { rdf } from '../../utils'
-import ExecutionContext from '../../engine/context/execution-context'
-
-const BIND_JOIN_BUFFER_SIZE = 15
-
-export type BGPBucket = Algebra.TripleObject[][]
-
-export type RewritingTable = Map<number, Bindings>
-
-/**
- * Rewrite a triple pattern using a rewriting key, i.e., append "_key" to each SPARQL variable in the triple pattern
- * @private
- * @param key - Rewriting key
- * @param tp - Triple pattern to rewrite
- * @return The rewritten triple pattern
- */
-function rewriteTriple (triple: Algebra.TripleObject, key: number) {
-  const res = Object.assign({}, triple)
-
-  if (rdf.isVariable(triple.subject)) {
-    res.subject = triple.subject + '_' + key
-  }
-  if (rdf.isVariable(triple.predicate)) {
-    res.predicate = triple.predicate + '_' + key
-  }
-  if (rdf.isVariable(triple.object)) {
-    res.object = triple.object + '_' + key
-  }
-  return res
-}
-
-/**
- * Find a rewriting key in a list of variables
- * For example, in [ ?s, ?o_1 ], the rewriting key is 1
- * @private
- */
-function findKey (variables: IterableIterator<string>, maxValue = 15) {
-  let key = -1
-  for (let v of variables) {
-    for (var i = 0; i < maxValue; i++) {
-      if (v.endsWith('_' + i)) {
-        return i
-      }
-    }
-  }
-  return key
-}
-
-/**
- * Undo the bound join rewriting on solutions bindings, e.g., rewrite all variables "?o_1" to "?o"
- * @private
- */
-function revertBinding (key: number, input: Bindings, variables: IterableIterator<string>) {
-  const newBinding = input.empty()
-  for (let vName of variables) {
-    if (vName.endsWith('_' + key)) {
-      const index = vName.indexOf('_' + key)
-      newBinding.set(vName.substring(0, index), input.get(vName)!)
-    } else {
-      newBinding.set(vName, input.get(vName)!)
-    }
-  }
-  return newBinding
-}
-
-/**
- * Undo the rewriting on solutions bindings, and then merge each of them with the corresponding input binding
- * @private
- */
-function rewriteSolutions (bindings: Bindings, rewritingMap: RewritingTable): Bindings {
-  const key = findKey(bindings.variables())
-  // rewrite binding, and then merge it with the corresponding one in the bucket
-  let newBinding = revertBinding(key, bindings, bindings.variables())
-  if (rewritingMap.has(key)) {
-    newBinding = newBinding.union(rewritingMap.get(key)!)
-  }
-  return newBinding
-}
-
-/**
- * A special operator used to evaluate a UNION query with a Sage server,
- * and then rewrite bindings generated and performs union with original bindings.
- * @author Thomas Minier
- * @private
- * @param  graph - Graph queried
- * @param  bgpBucket - List of BGPs to evaluate
- * @param  rewritingTable - Map <rewriting key -> original bindings>
- * @param  options - Query execution option
- * @return An Observable which evaluates the query.
- */
-function rewritingOp (graph: Graph, bgpBucket: BGPBucket, rewritingTable: RewritingTable, context: ExecutionContext): Observable<Bindings> {
-  return from(graph.evalUnion(bgpBucket, context))
-    .pipe(map(bindings => {
-      const x = rewriteSolutions(bindings, rewritingTable)
-      return x
-    }))
-}
-
-/**
- * Performs a Bound Join
- * see https://link.springer.com/content/pdf/10.1007/978-3-642-25073-6_38.pdf for more details
- * @author Thomas Minier
- * @param  source - Source of bindings
- * @param  bgp - Basic Pattern to join with
- * @param  graph - Graphe queried
- * @param  options - Query execution options
- * @return An observable which evaluates the bound join
- */
-export default function boundJoin (source: Observable<Bindings>, bgp: Algebra.TripleObject[], graph: Graph, context: ExecutionContext): Observable<Bindings> {
-  return new Observable(observer => {
-    let sourceClosed = false
-    let activeIterators = 0
-
-    // utility function used to close the observable
-    function tryClose () {
-      activeIterators--
-      if (sourceClosed && activeIterators === 0) {
-        observer.complete()
-      }
-    }
-
-    return source
-      .pipe(bufferCount(BIND_JOIN_BUFFER_SIZE))
-      .subscribe({
-        next: bucket => {
-          activeIterators++
-          // simple case: first join in the pipeline
-          if (bucket.length === 1 && bucket[0].isEmpty) {
-            from(graph.evalBGP(bgp, context)).subscribe(b => {
-              observer.next(b)
-            }, err => observer.error(err), () => tryClose())
-          } else {
-            // create bound join and execute it
-            const bgpBucket: BGPBucket = []
-            const rewritingTable = new Map()
-            let key = 0
-
-            // build the BGP bucket
-            bucket.map(binding => {
-              const boundedBGP: Algebra.TripleObject[] = []
-              bgp.forEach(triple => {
-                let boundedTriple = binding.bound(triple)
-                // rewrite triple and registerthe rewiriting
-                boundedTriple = rewriteTriple(boundedTriple, key)
-                rewritingTable.set(key, binding)
-                boundedBGP.push(boundedTriple)
-              })
-              bgpBucket.push(boundedBGP)
-              key++
-            })
-            // execute the bucket
-            rewritingOp(graph, bgpBucket, rewritingTable, context)
-              .subscribe(b => observer.next(b), err => observer.error(err), () => tryClose())
-          }
-        },
-        error: err => observer.error(err),
-        complete: () => { sourceClosed = true }
-      })
-  })
-}
+// /* file : bound-join.ts
+// MIT License
+//
+// Copyright (c) 2018 Thomas Minier
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// */
+//
+// import { Pipeline } from '../../engine/pipeline/pipeline'
+// import { PipelineStage } from '../../engine/pipeline/pipeline-engine'
+// // import { Observable, from } from 'rxjs'
+// // import { bufferCount, map } from 'rxjs/operators'
+// import Graph from '../../rdf/graph'
+// import { Bindings } from '../../rdf/bindings'
+// import { Algebra } from 'sparqljs'
+// import { rdf } from '../../utils'
+// import ExecutionContext from '../../engine/context/execution-context'
+//
+// const BIND_JOIN_BUFFER_SIZE = 15
+//
+// export type BGPBucket = Algebra.TripleObject[][]
+//
+// export type RewritingTable = Map<number, Bindings>
+//
+// /**
+//  * Rewrite a triple pattern using a rewriting key, i.e., append "_key" to each SPARQL variable in the triple pattern
+//  * @private
+//  * @param key - Rewriting key
+//  * @param tp - Triple pattern to rewrite
+//  * @return The rewritten triple pattern
+//  */
+// function rewriteTriple (triple: Algebra.TripleObject, key: number) {
+//   const res = Object.assign({}, triple)
+//
+//   if (rdf.isVariable(triple.subject)) {
+//     res.subject = triple.subject + '_' + key
+//   }
+//   if (rdf.isVariable(triple.predicate)) {
+//     res.predicate = triple.predicate + '_' + key
+//   }
+//   if (rdf.isVariable(triple.object)) {
+//     res.object = triple.object + '_' + key
+//   }
+//   return res
+// }
+//
+// /**
+//  * Find a rewriting key in a list of variables
+//  * For example, in [ ?s, ?o_1 ], the rewriting key is 1
+//  * @private
+//  */
+// function findKey (variables: IterableIterator<string>, maxValue = 15) {
+//   let key = -1
+//   for (let v of variables) {
+//     for (var i = 0; i < maxValue; i++) {
+//       if (v.endsWith('_' + i)) {
+//         return i
+//       }
+//     }
+//   }
+//   return key
+// }
+//
+// /**
+//  * Undo the bound join rewriting on solutions bindings, e.g., rewrite all variables "?o_1" to "?o"
+//  * @private
+//  */
+// function revertBinding (key: number, input: Bindings, variables: IterableIterator<string>) {
+//   const newBinding = input.empty()
+//   for (let vName of variables) {
+//     if (vName.endsWith('_' + key)) {
+//       const index = vName.indexOf('_' + key)
+//       newBinding.set(vName.substring(0, index), input.get(vName)!)
+//     } else {
+//       newBinding.set(vName, input.get(vName)!)
+//     }
+//   }
+//   return newBinding
+// }
+//
+// /**
+//  * Undo the rewriting on solutions bindings, and then merge each of them with the corresponding input binding
+//  * @private
+//  */
+// function rewriteSolutions (bindings: Bindings, rewritingMap: RewritingTable): Bindings {
+//   const key = findKey(bindings.variables())
+//   // rewrite binding, and then merge it with the corresponding one in the bucket
+//   let newBinding = revertBinding(key, bindings, bindings.variables())
+//   if (rewritingMap.has(key)) {
+//     newBinding = newBinding.union(rewritingMap.get(key)!)
+//   }
+//   return newBinding
+// }
+//
+// /**
+//  * A special operator used to evaluate a UNION query with a Sage server,
+//  * and then rewrite bindings generated and performs union with original bindings.
+//  * @author Thomas Minier
+//  * @private
+//  * @param  graph - Graph queried
+//  * @param  bgpBucket - List of BGPs to evaluate
+//  * @param  rewritingTable - Map <rewriting key -> original bindings>
+//  * @param  options - Query execution option
+//  * @return An Observable which evaluates the query.
+//  */
+// function rewritingOp (graph: Graph, bgpBucket: BGPBucket, rewritingTable: RewritingTable, context: ExecutionContext): PipelineStage<Bindings> {
+//   const engine = Pipeline.getInstance()
+//   return engine.map(engine.from(graph.evalUnion(bgpBucket, context)), bindings => {
+//     const x = rewriteSolutions(bindings, rewritingTable)
+//     return x
+//   })
+//   // return from(graph.evalUnion(bgpBucket, context))
+//   //   .pipe(map(bindings => {
+//   //     const x = rewriteSolutions(bindings, rewritingTable)
+//   //     return x
+//   //   }))
+// }
+//
+// /**
+//  * Performs a Bound Join
+//  * see https://link.springer.com/content/pdf/10.1007/978-3-642-25073-6_38.pdf for more details
+//  * @author Thomas Minier
+//  * @param  source - Source of bindings
+//  * @param  bgp - Basic Pattern to join with
+//  * @param  graph - Graphe queried
+//  * @param  options - Query execution options
+//  * @return An observable which evaluates the bound join
+//  */
+// export default function boundJoin (source: PipelineStage<Bindings>, bgp: Algebra.TripleObject[], graph: Graph, context: ExecutionContext): PipelineStage<Bindings> {
+//   return new Observable(observer => {
+//     let sourceClosed = false
+//     let activeIterators = 0
+//
+//     // utility function used to close the observable
+//     function tryClose () {
+//       activeIterators--
+//       if (sourceClosed && activeIterators === 0) {
+//         observer.complete()
+//       }
+//     }
+//
+//     return source
+//       .pipe(bufferCount(BIND_JOIN_BUFFER_SIZE))
+//       .subscribe({
+//         next: bucket => {
+//           activeIterators++
+//           // simple case: first join in the pipeline
+//           if (bucket.length === 1 && bucket[0].isEmpty) {
+//             from(graph.evalBGP(bgp, context)).subscribe(b => {
+//               observer.next(b)
+//             }, err => observer.error(err), () => tryClose())
+//           } else {
+//             // create bound join and execute it
+//             const bgpBucket: BGPBucket = []
+//             const rewritingTable = new Map()
+//             let key = 0
+//
+//             // build the BGP bucket
+//             bucket.map(binding => {
+//               const boundedBGP: Algebra.TripleObject[] = []
+//               bgp.forEach(triple => {
+//                 let boundedTriple = binding.bound(triple)
+//                 // rewrite triple and registerthe rewiriting
+//                 boundedTriple = rewriteTriple(boundedTriple, key)
+//                 rewritingTable.set(key, binding)
+//                 boundedBGP.push(boundedTriple)
+//               })
+//               bgpBucket.push(boundedBGP)
+//               key++
+//             })
+//             // execute the bucket
+//             rewritingOp(graph, bgpBucket, rewritingTable, context)
+//               .subscribe(b => observer.next(b), err => observer.error(err), () => tryClose())
+//           }
+//         },
+//         error: err => observer.error(err),
+//         complete: () => { sourceClosed = true }
+//       })
+//   })
+// }

--- a/src/operators/join/hash-join.ts
+++ b/src/operators/join/hash-join.ts
@@ -29,10 +29,10 @@ import { Bindings } from '../../rdf/bindings'
 
 /**
  * Perform a traditional Hash join between two sources, i.e., materialize the right source in a hash table and then read from the left source while probing into the hash table.
- * @param  left - Left source
- * @param  right - Right source
+ * @param  left - Left source (a {@link PipelineStage})
+ * @param  right - Right source (a {@link PipelineStage})
  * @param  joinKey - SPARQL variable used as join attribute
- * @return An Observable which performs a Hash join
+ * @return A {@link PipelineStage} which performs a Hash join
  */
 export default function hashJoin (left: PipelineStage<Bindings>, right: PipelineStage<Bindings>, joinKey: string) {
   const joinTable = new HashJoinTable()

--- a/src/operators/join/index-join.ts
+++ b/src/operators/join/index-join.ts
@@ -38,9 +38,11 @@ import ExecutionContext from '../../engine/context/execution-context'
  * and a triple pattern (right relation) using the Index Nested Loop Join algorithm.
  * This algorithm is more efficient if the cardinality of the left relation is smaller
  * than the cardinality of the right one.
+ * @param source - Left input (a {@link PipelineStage})
  * @param pattern - Triple pattern to join with (right relation)
  * @param graph   - RDF Graph on which the join is performed
- * @param options - Execution options
+ * @param context - Execution context
+ * @return A {@link PipelineStage} which evaluate the join
  * @author Thomas Minier
  */
 export default function indexJoin (source: PipelineStage<Bindings>, pattern: Algebra.TripleObject, graph: Graph, context: ExecutionContext) {

--- a/src/operators/join/shjoin.ts
+++ b/src/operators/join/shjoin.ts
@@ -30,10 +30,10 @@ import { Bindings } from '../../rdf/bindings'
 /**
  * Utility function used to perform one half of a symmetric hash join
  * @param  joinKey - SPARQL variable used as join attribute
- * @param  source  - Source of bindings
+ * @param  source  - Source of bindings (a {@link PipelineStage})
  * @param  innerTable - Hash table in which bindings are inserted
  * @param  outerTable - Hash table in which bindings are probed
- * @return An Observable that performs one half of a symmetric hash join
+ * @return A {@link PipelineStage} that performs one half of a symmetric hash join
  */
 function halfHashJoin (joinKey: string, source: PipelineStage<Bindings>, innerTable: HashJoinTable, outerTable: HashJoinTable): PipelineStage<Bindings> {
   const engine = Pipeline.getInstance()
@@ -54,9 +54,9 @@ function halfHashJoin (joinKey: string, source: PipelineStage<Bindings>, innerTa
 /**
  * Perform a Symmetric Hash Join between two sources
  * @param  joinKey - SPARQL variable used as join attribute
- * @param  left - Left source
- * @param  right - Right source
- * @return An Observable that performs a symmetric hash join between the sources
+ * @param  left - Left source (a {@link PipelineStage})
+ * @param  right - Right source (a {@link PipelineStage})
+ * @return A {@link PipelineStage} that performs a symmetric hash join between the sources
  */
 export default function symHashJoin (joinKey: string, left: PipelineStage<Bindings>, right: PipelineStage<Bindings>) {
   const leftTable = new HashJoinTable()

--- a/src/operators/minus.ts
+++ b/src/operators/minus.ts
@@ -24,34 +24,32 @@ SOFTWARE.
 
 'use strict'
 
-import { Observable } from 'rxjs'
-import { mergeMap, filter , reduce} from'rxjs/operators'
+import { Pipeline } from '../engine/pipeline/pipeline'
+import { PipelineStage } from '../engine/pipeline/pipeline-engine'
 import { concat, intersection } from 'lodash'
 import { Bindings } from '../rdf/bindings'
 
 /**
  * Evaluates a SPARQL MINUS clause
  * @see {@link https://www.w3.org/TR/sparql11-query/#neg-minus}
- * @extends TransformIterator
  * @author Thomas Minier
  */
-export default function minus (source: Observable<Bindings>, rightSource: Observable<Bindings>) {
+export default function minus (source: PipelineStage<Bindings>, rightSource: PipelineStage<Bindings>) {
   // first materialize the right source in a buffer, then apply difference on the left source
-  return rightSource
-    .pipe(reduce((acc: Bindings[], b: Bindings) => concat(acc, b), []))
-    .pipe(mergeMap((buffer: Bindings[]) => {
-      return source
-        .pipe(filter((bindings: Bindings) => {
-          const leftKeys = Array.from(bindings.variables())
-          // mu_a is compatible with mu_b if,
-          // for all v in intersection(dom(mu_a), dom(mu_b)), mu_a[v] = mu_b[v]
-          const isCompatible = buffer.some((b: Bindings) => {
-            const rightKeys = Array.from(b.variables())
-            const commonKeys = intersection(leftKeys, rightKeys)
-            return commonKeys.every((k: string) => b.get(k) === bindings.get(k))
-          })
-          // only output non-compatible bindings
-        return !isCompatible
-        }))
-    }))
+  const engine = Pipeline.getInstance()
+  let op = engine.reduce(rightSource, (acc: Bindings[], b: Bindings) => concat(acc, b), [])
+  return engine.mergeMap(op, (buffer: Bindings[]) => {
+    return engine.filter(source, (bindings: Bindings) => {
+      const leftKeys = Array.from(bindings.variables())
+      // mu_a is compatible with mu_b if,
+      // for all v in intersection(dom(mu_a), dom(mu_b)), mu_a[v] = mu_b[v]
+      const isCompatible = buffer.some((b: Bindings) => {
+        const rightKeys = Array.from(b.variables())
+        const commonKeys = intersection(leftKeys, rightKeys)
+        return commonKeys.every((k: string) => b.get(k) === bindings.get(k))
+      })
+      // only output non-compatible bindings
+    return !isCompatible
+    })
+  })
 }

--- a/src/operators/minus.ts
+++ b/src/operators/minus.ts
@@ -33,13 +33,16 @@ import { Bindings } from '../rdf/bindings'
  * Evaluates a SPARQL MINUS clause
  * @see {@link https://www.w3.org/TR/sparql11-query/#neg-minus}
  * @author Thomas Minier
+ * @param leftSource - Left input {@link PipelineStage}
+ * @param rightSource - Right input {@link PipelineStage}
+ * @return A {@link PipelineStage} which evaluate the MINUS operation
  */
-export default function minus (source: PipelineStage<Bindings>, rightSource: PipelineStage<Bindings>) {
+export default function minus (leftSource: PipelineStage<Bindings>, rightSource: PipelineStage<Bindings>) {
   // first materialize the right source in a buffer, then apply difference on the left source
   const engine = Pipeline.getInstance()
   let op = engine.reduce(rightSource, (acc: Bindings[], b: Bindings) => concat(acc, b), [])
   return engine.mergeMap(op, (buffer: Bindings[]) => {
-    return engine.filter(source, (bindings: Bindings) => {
+    return engine.filter(leftSource, (bindings: Bindings) => {
       const leftKeys = Array.from(bindings.variables())
       // mu_a is compatible with mu_b if,
       // for all v in intersection(dom(mu_a), dom(mu_b)), mu_a[v] = mu_b[v]

--- a/src/operators/modifiers/ask.ts
+++ b/src/operators/modifiers/ask.ts
@@ -24,8 +24,8 @@ SOFTWARE.
 
 'use strict'
 
-import { Observable } from 'rxjs'
-import { first, map, defaultIfEmpty } from 'rxjs/operators'
+import { Pipeline } from '../../engine/pipeline/pipeline'
+import { PipelineStage } from '../../engine/pipeline/pipeline-engine'
 import { Bindings, BindingBase } from '../../rdf/bindings'
 
 /**
@@ -35,12 +35,10 @@ import { Bindings, BindingBase } from '../../rdf/bindings'
  * @author Thomas Minier
  * @param source - Source observable
  */
-export default function ask (source: Observable<Bindings>) {
+export default function ask (source: PipelineStage<Bindings>) {
   const defaultValue: Bindings = new BindingBase()
-  return source
-    .pipe(defaultIfEmpty(defaultValue))
-    .pipe(first())
-    .pipe(map((b: Bindings) => {
-      return b.size > 0
-    }))
+  const engine = Pipeline.getInstance()
+  let op = engine.defaultValues(source, defaultValue)
+  op = engine.first(op)
+  return engine.map(op, b => b.size > 0)
 }

--- a/src/operators/modifiers/ask.ts
+++ b/src/operators/modifiers/ask.ts
@@ -33,7 +33,8 @@ import { Bindings, BindingBase } from '../../rdf/bindings'
  * results are outputed following the SPARQL XML results format
  * @see {@link https://www.w3.org/TR/2013/REC-sparql11-query-20130321/#ask}
  * @author Thomas Minier
- * @param source - Source observable
+ * @param source - Source {@link PipelineStage}
+ * @return A {@link PipelineStage} that evaluate the ASK modifier
  */
 export default function ask (source: PipelineStage<Bindings>) {
   const defaultValue: Bindings = new BindingBase()

--- a/src/operators/modifiers/construct.ts
+++ b/src/operators/modifiers/construct.ts
@@ -34,8 +34,9 @@ import { Bindings } from '../../rdf/bindings'
 /**
  * A ConstructOperator transform solution mappings into RDF triples, according to a template
  * @see {@link https://www.w3.org/TR/2013/REC-sparql11-query-20130321/#construct}
- * @param source  - Source observable
+ * @param source  - Source {@link PipelineStage}
  * @param templates - Set of triples patterns in the CONSTRUCT clause
+ * @return A {@link PipelineStage} which evaluate the CONSTRUCT modifier
  * @author Thomas Minier
  */
 export default function construct (source: PipelineStage<Bindings>, query: any) {

--- a/src/operators/modifiers/select.ts
+++ b/src/operators/modifiers/select.ts
@@ -33,9 +33,11 @@ import { Bindings } from '../../rdf/bindings'
 /**
  * Evaluates a SPARQL SELECT operation, i.e., perform a selection over sets of solutions bindings
  * @see {@link https://www.w3.org/TR/2013/REC-sparql11-query-20130321/#select}
- * @param query - SELECT query
  * @author Thomas Minier
  * @author Corentin Marionneau
+ * @param source - Input {@link PipelineStage}
+ * @param query - SELECT query
+ * @return A {@link PipelineStage} which evaluate the SELECT modifier
  */
 export default function select (source: PipelineStage<Bindings>, query: Algebra.RootNode) {
   const variables = <string[]> query.variables

--- a/src/operators/modifiers/select.ts
+++ b/src/operators/modifiers/select.ts
@@ -24,8 +24,8 @@ SOFTWARE.
 
 'use strict'
 
-import { Observable } from 'rxjs'
-import { map } from 'rxjs/operators'
+import { Pipeline } from '../../engine/pipeline/pipeline'
+import { PipelineStage } from '../../engine/pipeline/pipeline-engine'
 import { Algebra } from 'sparqljs'
 import { rdf } from '../../utils'
 import { Bindings } from '../../rdf/bindings'
@@ -37,10 +37,10 @@ import { Bindings } from '../../rdf/bindings'
  * @author Thomas Minier
  * @author Corentin Marionneau
  */
-export default function select (source: Observable<Bindings>, query: Algebra.RootNode) {
+export default function select (source: PipelineStage<Bindings>, query: Algebra.RootNode) {
   const variables = <string[]> query.variables
   const selectAll = variables.length === 1 && variables[0] === '*'
-  return source.pipe(map((bindings: Bindings) => {
+  return Pipeline.getInstance().map(source, (bindings: Bindings) => {
     if (!selectAll) {
       bindings = variables.reduce((obj, v) => {
         if (bindings.has(v)) {
@@ -52,5 +52,5 @@ export default function select (source: Observable<Bindings>, query: Algebra.Roo
       }, bindings.empty())
     }
     return bindings.mapValues((k, v) => rdf.isVariable(k) && typeof v === 'string' ? v : null)
-  }))
+  })
 }

--- a/src/operators/optional.ts
+++ b/src/operators/optional.ts
@@ -32,13 +32,14 @@ import { Bindings } from '../rdf/bindings'
 import ExecutionContext from '../engine/context/execution-context'
 
 /**
- * Handles an SPARQL OPTIONAL clause in the following way:
- * 1) Buffer every bindings produced by the source iterator.
- * 2) Set a flag to False if the OPTIONAL clause yield at least one set of bindings.
- * 3) When the OPTIONAL clause if evaluated, check if the flag is True.
- * 4) If the flag is True, then we output all buffered values. Otherwise, we do nothing.
+ * Handles an SPARQL OPTIONAL clause
  * @see {@link https://www.w3.org/TR/sparql11-query/#optionals}
  * @author Thomas Minier
+ * @param source - Input {@link PipelineStage}
+ * @param patterns - OPTIONAL clause, i.e., a SPARQL group pattern
+ * @param builder - Instance of the current {@link PlanBuilder}
+ * @param context - Execution context
+ * @return A {@link PipelineStage} which evaluate the OPTIONAL operation
  */
 export default function optional (source: PipelineStage<Bindings>, patterns: Algebra.PlanNode[], builder: PlanBuilder, context: ExecutionContext): PipelineStage<Bindings> {
   const seenBefore: Bindings[] = []

--- a/src/operators/orderby.ts
+++ b/src/operators/orderby.ts
@@ -61,9 +61,11 @@ function _compileComparators (comparators: Algebra.OrderComparator[]) {
 /**
  * A OrderByOperator implements a ORDER BY clause, i.e.,
  * it sorts solution mappings produced by another operator
- * @extends MaterializeOperator
- * @author Thomas Minier
  * @see {@link https://www.w3.org/TR/2013/REC-sparql11-query-20130321/#modOrderBy}
+ * @author Thomas Minier
+ * @param source - Input {@link PipelineStage}
+ * @param comparators - Set of ORDER BY comparators
+ * @return A {@link PipelineStage} which evaluate the ORDER BY operation
  */
 export default function orderby (source: PipelineStage<Bindings>, comparators: Algebra.OrderComparator[]) {
   const comparator = _compileComparators(comparators.map((c: Algebra.OrderComparator) => {

--- a/src/operators/sparql-distinct.ts
+++ b/src/operators/sparql-distinct.ts
@@ -24,7 +24,8 @@ SOFTWARE.
 
 'use strict'
 
-import { distinct } from 'rxjs/operators'
+import { Pipeline } from '../engine/pipeline/pipeline'
+import { PipelineStage } from '../engine/pipeline/pipeline-engine'
 import { Bindings } from '../rdf/bindings'
 
 /**
@@ -44,6 +45,6 @@ function _hash (bindings: Bindings): string {
  * @see {@link https://www.w3.org/TR/2013/REC-sparql11-query-20130321/#modDuplicates}
  * @author Thomas Minier
  */
-export default function sparqlDistinct () {
-  return distinct((bindings: Bindings) => _hash(bindings))
+export default function sparqlDistinct (source: PipelineStage<Bindings>) {
+  return Pipeline.getInstance().distinct(source, (bindings: Bindings) => _hash(bindings))
 }

--- a/src/operators/sparql-distinct.ts
+++ b/src/operators/sparql-distinct.ts
@@ -30,6 +30,7 @@ import { Bindings } from '../rdf/bindings'
 
 /**
  * Hash an set of mappings and produce an unique value
+ * @private
  * @param item - The item to hash
  * @return An unique hash which identify the item
  */
@@ -44,6 +45,8 @@ function _hash (bindings: Bindings): string {
  * Applies a DISTINCT modifier on the output of another operator.
  * @see {@link https://www.w3.org/TR/2013/REC-sparql11-query-20130321/#modDuplicates}
  * @author Thomas Minier
+ * @param source - Input {@link PipelineStage}
+ * @return A {@link PipelineStage} which evaluate the DISTINCT operation
  */
 export default function sparqlDistinct (source: PipelineStage<Bindings>) {
   return Pipeline.getInstance().distinct(source, (bindings: Bindings) => _hash(bindings))

--- a/src/operators/sparql-filter.ts
+++ b/src/operators/sparql-filter.ts
@@ -35,8 +35,10 @@ import { CustomFunctions } from "../engine/plan-builder"
  * Evaluate SPARQL Filter clauses
  * @see {@link https://www.w3.org/TR/sparql11-query/#expressions}
  * @author Thomas Minier
+ * @param source - Input {@link PipelineStage}
  * @param expression - FILTER expression
- * @return A Filter operator
+ * @param customFunctions - User-defined SPARQL functions (optional)
+ * @return A {@link PipelineStage} which evaluate the FILTER operation
  */
 export default function sparqlFilter (source: PipelineStage<Bindings>, expression: Algebra.Expression, customFunctions?: CustomFunctions) {
   const expr = new SPARQLExpression(expression, customFunctions)

--- a/src/operators/sparql-filter.ts
+++ b/src/operators/sparql-filter.ts
@@ -24,7 +24,8 @@ SOFTWARE.
 
 'use strict'
 
-import { filter } from 'rxjs/operators'
+import { Pipeline } from '../engine/pipeline/pipeline'
+import { PipelineStage } from '../engine/pipeline/pipeline-engine'
 import SPARQLExpression from './expressions/sparql-expression'
 import { Algebra } from 'sparqljs'
 import { Bindings } from '../rdf/bindings'
@@ -37,9 +38,9 @@ import { CustomFunctions } from "../engine/plan-builder"
  * @param expression - FILTER expression
  * @return A Filter operator
  */
-export default function sparqlFilter (expression: Algebra.Expression, customFunctions?: CustomFunctions) {
+export default function sparqlFilter (source: PipelineStage<Bindings>, expression: Algebra.Expression, customFunctions?: CustomFunctions) {
   const expr = new SPARQLExpression(expression, customFunctions)
-  return filter((bindings: Bindings) => {
+  return Pipeline.getInstance().filter(source, (bindings: Bindings) => {
     const value: any = expr.evaluate(bindings)
     return value !== null && value.asJS
   })

--- a/src/operators/sparql-groupby.ts
+++ b/src/operators/sparql-groupby.ts
@@ -41,6 +41,13 @@ function buildNewGroup (variables: string[]): Object {
   }, {})
 }
 
+/**
+ * Hash functions for set of bindings
+ * @private
+ * @param  variables - SPARQL variables to hash
+ * @param  bindings  - Set of bindings to hash
+ * @return Hashed set of bindings
+ */
 function _hashBindings (variables: string[], bindings: Bindings): string {
   return variables.map(v => {
     if (bindings.has(v)) {
@@ -52,8 +59,11 @@ function _hashBindings (variables: string[], bindings: Bindings): string {
 
 /**
  * Apply a SPARQL GROUP BY clause
- * @see https://www.w3.org/TR/sparql11-query/#groupby
+ * @see {@link https://www.w3.org/TR/sparql11-query/#groupby}
  * @author Thomas Minier
+ * @param source - Input {@link PipelineStage}
+ * @param variables - GROUP BY variables
+ * @return A {@link PipelineStage} which evaluate the GROUP BY operation
  */
 export default function sparqlGroupBy (source: PipelineStage<Bindings>, variables: string[]) {
   const groups: Map<string, any> = new Map()

--- a/src/operators/update/consumer.ts
+++ b/src/operators/update/consumer.ts
@@ -24,7 +24,7 @@ SOFTWARE.
 
 'use strict'
 
-import { Observable } from 'rxjs'
+import { PipelineStage } from '../../engine/pipeline/pipeline-engine'
 import { Writable } from 'stream'
 import { Algebra } from 'sparqljs'
 
@@ -65,7 +65,7 @@ export class ErrorConsumable implements Consumable {
  * @author Thomas Minier
  */
 export abstract class Consumer extends Writable implements Consumable {
-  private readonly _source: Observable<Algebra.TripleObject>
+  private readonly _source: PipelineStage<Algebra.TripleObject>
   private readonly _options: Object
 
   /**
@@ -73,7 +73,7 @@ export abstract class Consumer extends Writable implements Consumable {
    * @param source - Source iterator
    * @param options - Execution options
    */
-  constructor (source: Observable<Algebra.TripleObject>, options: Object) {
+  constructor (source: PipelineStage<Algebra.TripleObject>, options: Object) {
     super({ objectMode: true })
     this._source = source
     this._options = options

--- a/src/operators/update/consumer.ts
+++ b/src/operators/update/consumer.ts
@@ -70,7 +70,7 @@ export abstract class Consumer extends Writable implements Consumable {
 
   /**
    * Constructor
-   * @param source - Source iterator
+   * @param source - Input {@link PipelineStage}
    * @param options - Execution options
    */
   constructor (source: PipelineStage<Algebra.TripleObject>, options: Object) {

--- a/src/operators/update/delete-consumer.ts
+++ b/src/operators/update/delete-consumer.ts
@@ -26,7 +26,7 @@ SOFTWARE.
 
 import { Consumer } from './consumer'
 import Graph from '../../rdf/graph'
-import { Observable } from 'rxjs'
+import { PipelineStage } from '../../engine/pipeline/pipeline-engine'
 import { Algebra } from 'sparqljs'
 
 /**
@@ -43,7 +43,7 @@ export default class DeleteConsumer extends Consumer {
    * @param graph - Input RDF Graph
    * @param options - Execution options
    */
-  constructor (source: Observable<Algebra.TripleObject>, graph: Graph, options: Object) {
+  constructor (source: PipelineStage<Algebra.TripleObject>, graph: Graph, options: Object) {
     super(source, options)
     this._graph = graph
   }

--- a/src/operators/update/delete-consumer.ts
+++ b/src/operators/update/delete-consumer.ts
@@ -39,7 +39,7 @@ export default class DeleteConsumer extends Consumer {
 
   /**
    * Constructor
-   * @param source - Source iterator
+   * @param source - Input {@link PipelineStage}
    * @param graph - Input RDF Graph
    * @param options - Execution options
    */

--- a/src/operators/update/insert-consumer.ts
+++ b/src/operators/update/insert-consumer.ts
@@ -39,7 +39,7 @@ export default class InsertConsumer extends Consumer {
 
   /**
    * Constructor
-   * @param source - Source iterator
+   * @param source - Input {@link PipelineStage}
    * @param graph - Input RDF Graph
    * @param options - Execution options
    */

--- a/src/operators/update/insert-consumer.ts
+++ b/src/operators/update/insert-consumer.ts
@@ -26,7 +26,7 @@ SOFTWARE.
 
 import { Consumer } from './consumer'
 import Graph from '../../rdf/graph'
-import { Observable } from 'rxjs'
+import { PipelineStage } from '../../engine/pipeline/pipeline-engine'
 import { Algebra } from 'sparqljs'
 
 /**
@@ -43,7 +43,7 @@ export default class InsertConsumer extends Consumer {
    * @param graph - Input RDF Graph
    * @param options - Execution options
    */
-  constructor (source: Observable<Algebra.TripleObject>, graph: Graph, options: Object) {
+  constructor (source: PipelineStage<Algebra.TripleObject>, graph: Graph, options: Object) {
     super(source, options)
     this._graph = graph
   }

--- a/src/rdf-terms.ts
+++ b/src/rdf-terms.ts
@@ -73,8 +73,6 @@ function literalToJS (value: string, type: string): any {
 
 /**
  * Utilities used to manipulate RDF terms
- * @param  iri [description]
- * @return     [description]
  */
 export namespace terms {
   /**

--- a/src/rdf/dataset.ts
+++ b/src/rdf/dataset.ts
@@ -49,20 +49,20 @@ export default abstract class Dataset {
   /**
    * Add a Named Graph to the Dataset
    * @param iri - IRI of the Named Graph
-   * @param g    - RDF Graph
+   * @param g   - RDF Graph
    */
   abstract addNamedGraph (iri: string, g: Graph): void
 
   /**
    * Get a Named Graph using its IRI
-   * @param  {string} iri - IRI of the Named Graph to retrieve
+   * @param  iri - IRI of the Named Graph to retrieve
    * @return The corresponding Named Graph
    */
   abstract getNamedGraph (iri: string): Graph
 
   /**
    * Return True if the Dataset contains a Named graph with the provided IRI
-   * @param  {string} iri - IRI of the Named Graph
+   * @param  iri - IRI of the Named Graph
    * @return True if the Dataset contains a Named graph with the provided IRI
    */
   abstract hasNamedGraph (iri: string): boolean
@@ -70,8 +70,8 @@ export default abstract class Dataset {
   /**
    * Get an UnionGraph, i.e., the dynamic union of several graphs,
    * from the RDF Graphs in the Dataset.
-   * @param  {string[]} iris                  - Iris of the named graphs to include in the union
-   * @param  {Boolean} [includeDefault=false] - True if the default graph should be included
+   * @param  iris           - Iris of the named graphs to include in the union
+   * @param  includeDefault - True if the default graph should be included
    * @return The dynamic union of several graphs in the Dataset
    */
   getUnionGraph (iris: string[], includeDefault: boolean = false): UnionGraph {
@@ -85,7 +85,7 @@ export default abstract class Dataset {
 
   /**
    * Returns all Graphs in the Dataset, including the Default one
-   * @param  {Boolean} [includeDefault=false] - True if the default graph should be included
+   * @param  includeDefault - True if the default graph should be included
    * @return The list of all graphs in the Dataset
    */
   getAllGraphs (includeDefault: boolean = true): Graph[] {

--- a/src/rdf/graph.ts
+++ b/src/rdf/graph.ts
@@ -47,8 +47,8 @@ export interface PatternMetadata {
  * Comparator function for sorting triple pattern
  * by ascending cardinality and descending number of variables
  * @private
- * @param  {Object} a - Metadata about left triple
- * @param  {Object} b - Metadata about right triple
+ * @param  a - Metadata about left triple
+ * @param  b - Metadata about right triple
  * @return Comparaison result (-1, 1, 0)
  */
 function sortPatterns (a: PatternMetadata, b: PatternMetadata): number {
@@ -126,7 +126,7 @@ export default abstract class Graph {
   /**
    * Returns an iterator that finds RDF triples matching a triple pattern in the graph.
    * @param  triple - Triple pattern to find
-   * @return An iterator which finds RDF triples matching a triple pattern
+   * @return A {@link PipelineStage} which finds RDF triples matching a triple pattern
    */
   abstract find (triple: Algebra.TripleObject, context: ExecutionContext): ObservableInput<Algebra.TripleObject>
 
@@ -146,20 +146,20 @@ export default abstract class Graph {
   }
 
   /**
-   * Evaluates an union of Basic Graph patterns on the Graph using an iterator.
+   * Evaluates an union of Basic Graph patterns on the Graph using a {@link PipelineStage}.
    * @param  patterns - The set of BGPs to evaluate
    * @param  options - Execution options
-   * @return An iterator which evaluates the Basic Graph pattern on the Graph
+   * @return A {@link PipelineStage} which evaluates the Basic Graph pattern on the Graph
    */
   evalUnion (patterns: Algebra.TripleObject[][], context: ExecutionContext): ObservableInput<Bindings> {
     throw new SyntaxError('Error: this graph is not capable of evaluating UNION queries')
   }
 
   /**
-   * Evaluates a Basic Graph pattern, i.e., a set of triple patterns, on the Graph using an iterator.
+   * Evaluates a Basic Graph pattern, i.e., a set of triple patterns, on the Graph using a {@link PipelineStage}.
    * @param  bgp - The set of triple patterns to evaluate
    * @param  options - Execution options
-   * @return An iterator which evaluates the Basic Graph pattern on the Graph
+   * @return A {@link PipelineStage} which evaluates the Basic Graph pattern on the Graph
    */
   evalBGP (bgp: Algebra.TripleObject[], context: ExecutionContext): PipelineStage<Bindings> {
     const engine = Pipeline.getInstance()

--- a/src/rdf/graph.ts
+++ b/src/rdf/graph.ts
@@ -25,8 +25,7 @@ SOFTWARE.
 'use strict'
 
 import { Pipeline } from '../engine/pipeline/pipeline'
-import { PipelineStage } from '../engine/pipeline/pipeline-engine'
-import { ObservableInput } from 'rxjs'
+import { PipelineInput, PipelineStage } from '../engine/pipeline/pipeline-engine'
 import { Algebra } from 'sparqljs'
 import indexJoin from '../operators/join/index-join'
 import { rdf } from '../utils'
@@ -124,11 +123,11 @@ export default abstract class Graph {
   abstract delete (triple: Algebra.TripleObject): Promise<void>
 
   /**
-   * Returns an iterator that finds RDF triples matching a triple pattern in the graph.
+   * Get a {@link PipelineInput} which finds RDF triples matching a triple pattern in the graph.
    * @param  triple - Triple pattern to find
-   * @return A {@link PipelineStage} which finds RDF triples matching a triple pattern
+   * @return A {@link PipelineInput} which finds RDF triples matching a triple pattern
    */
-  abstract find (triple: Algebra.TripleObject, context: ExecutionContext): ObservableInput<Algebra.TripleObject>
+  abstract find (triple: Algebra.TripleObject, context: ExecutionContext): PipelineInput<Algebra.TripleObject>
 
   /**
    * Remove all RDF triples in the Graph
@@ -151,7 +150,7 @@ export default abstract class Graph {
    * @param  options - Execution options
    * @return A {@link PipelineStage} which evaluates the Basic Graph pattern on the Graph
    */
-  evalUnion (patterns: Algebra.TripleObject[][], context: ExecutionContext): ObservableInput<Bindings> {
+  evalUnion (patterns: Algebra.TripleObject[][], context: ExecutionContext): PipelineStage<Bindings> {
     throw new SyntaxError('Error: this graph is not capable of evaluating UNION queries')
   }
 

--- a/src/rdf/union-graph.ts
+++ b/src/rdf/union-graph.ts
@@ -24,8 +24,9 @@ SOFTWARE.
 
 'use strict'
 
-import { ObservableInput, merge } from 'rxjs'
 import Graph from './graph'
+import { PipelineInput } from '../engine/pipeline/pipeline-engine'
+import { Pipeline } from '../engine/pipeline/pipeline'
 import { Algebra } from 'sparqljs'
 import ExecutionContext from '../engine/context/execution-context'
 
@@ -58,8 +59,8 @@ export default class UnionGraph extends Graph {
     return this._graphs.reduce((prev, g) => prev.then(() => g.delete(triple)), Promise.resolve())
   }
 
-  find (triple: Algebra.TripleObject, context: ExecutionContext): ObservableInput<Algebra.TripleObject> {
-    return merge(...this._graphs.map(g => g.find(triple, context)))
+  find (triple: Algebra.TripleObject, context: ExecutionContext): PipelineInput<Algebra.TripleObject> {
+    return Pipeline.getInstance().merge(...this._graphs.map(g => g.find(triple, context)))
   }
 
   clear (): Promise<void> {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -26,8 +26,8 @@ SOFTWARE.
 
 import { terms } from './rdf-terms'
 import { Util } from 'n3'
-import { Observable } from 'rxjs'
-import { map } from 'rxjs/operators'
+import { Pipeline } from './engine/pipeline/pipeline'
+import { PipelineStage } from './engine/pipeline/pipeline-engine'
 import { Algebra } from 'sparqljs'
 import { Bindings } from './rdf/bindings'
 
@@ -201,6 +201,6 @@ export function deepApplyBindings (group: Algebra.PlanNode, bindings: Bindings):
  * @param  bindings - Bindings added to each set of bindings procuded by the iterator
  * @return An iterator that extends bindins produced by the source iterator
  */
-export function extendByBindings (source: Observable<Bindings>, bindings: Bindings): Observable<Bindings> {
-  return source.pipe(map((b: Bindings) => bindings.union(b)))
+export function extendByBindings (source: PipelineStage<Bindings>, bindings: Bindings): PipelineStage<Bindings> {
+  return Pipeline.getInstance().map(source, (b: Bindings) => bindings.union(b))
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -163,8 +163,8 @@ export function applyBindings (triple: Algebra.TripleObject, bindings: Bindings)
 
 /**
  * Recursively apply bindings to every triple in a SPARQL group pattern
- * @param  {Object} group - SPARQL group pattern to process
- * @param  {Bindings} bindings - Set of bindings to use
+ * @param  group - SPARQL group pattern to process
+ * @param  bindings - Set of bindings to use
  * @return A new SPARQL group pattern with triples bounded
  */
 export function deepApplyBindings (group: Algebra.PlanNode, bindings: Bindings): Algebra.PlanNode {
@@ -197,9 +197,9 @@ export function deepApplyBindings (group: Algebra.PlanNode, bindings: Bindings):
 
 /**
  * Extends all set of bindings produced by an iterator with another set of bindings
- * @param  source - Source terator
+ * @param  source - Source {@link PipelineStage}
  * @param  bindings - Bindings added to each set of bindings procuded by the iterator
- * @return An iterator that extends bindins produced by the source iterator
+ * @return A {@link PipelineStage} that extends bindins produced by the source iterator
  */
 export function extendByBindings (source: PipelineStage<Bindings>, bindings: Bindings): PipelineStage<Bindings> {
   return Pipeline.getInstance().map(source, (b: Bindings) => bindings.union(b))

--- a/tests/operators/bind-test.js
+++ b/tests/operators/bind-test.js
@@ -41,7 +41,7 @@ describe('Bind operator', () => {
       operator: '+',
       args: ['?x', '?y']
     }
-    const op = source.pipe(bind('?z', expr))
+    const op = bind(source, '?z', expr)
     op.subscribe(value => {
       expect(value.toObject()).to.have.all.keys('?x', '?y', '?z')
       if (value.get('?x').startsWith('"1"')) {

--- a/tests/pipeline/fixtures.js
+++ b/tests/pipeline/fixtures.js
@@ -1,0 +1,515 @@
+/* file : fixtures.js
+MIT License
+
+Copyright (c) 2019 Thomas Minier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+'use strict'
+
+const expect = require('chai').expect
+
+/**
+ * Test an implementation of PipelineEngine
+ * @param  {PipelineEngine} pipeline - Pipeline engine to test
+ */
+function testPipelineEngine (pipeline) {
+  // empty method
+  describe('#empty', () => {
+    it('should create a PipelineStage which emits no items', done => {
+      const out = pipeline.empty()
+      let cpt = 0
+      out.subscribe(() => cpt++, done, () => {
+        expect(cpt).to.equal(0)
+        done()
+      })
+    })
+  })
+
+  // of method
+  describe('#of', () => {
+    it('should create a PipelineStage from a single element', done => {
+      const out = pipeline.of(1)
+      let cpt = 0
+      out.subscribe(x => {
+        expect(x).to.equal(1)
+        cpt++
+      }, done, () => {
+        expect(cpt).to.equal(1)
+        done()
+      })
+    })
+
+    it('should create a PipelineStage from several elements', done => {
+      const out = pipeline.of(1, 2, 3)
+      const expected = [1, 2, 3]
+      let cpt = 0
+      out.subscribe(x => {
+        expect(x).to.be.oneOf(expected)
+        // pull out element
+        expected.splice(expected.indexOf(x), 1)
+        cpt++
+      }, done, () => {
+        expect(cpt).to.equal(3)
+        expect(expected.length).to.equal(0)
+        done()
+      })
+    })
+  })
+
+  // from method
+  describe('#from', () => {
+    it('should create a PipelineStage from an array', done => {
+      const out = pipeline.from([1, 2, 3])
+      const expected = [1, 2, 3]
+      let cpt = 0
+      out.subscribe(x => {
+        expect(x).to.be.oneOf(expected)
+        // pull out element
+        expected.splice(expected.indexOf(x), 1)
+        cpt++
+      }, done, () => {
+        expect(cpt).to.equal(3)
+        expect(expected.length).to.equal(0)
+        done()
+      })
+    })
+
+    it('should create a PipelineStage from a Promise', done => {
+      const out = pipeline.from(Promise.resolve(1))
+      let cpt = 0
+      out.subscribe(x => {
+        expect(x).to.equal(1)
+        cpt++
+      }, done, () => {
+        expect(cpt).to.equal(1)
+        done()
+      })
+    })
+
+    it('should create a PipelineStage from another PipelineStage', done => {
+      const out = pipeline.from(pipeline.of(1))
+      let cpt = 0
+      out.subscribe(x => {
+        expect(x).to.equal(1)
+        cpt++
+      }, done, () => {
+        expect(cpt).to.equal(1)
+        done()
+      })
+    })
+  })
+
+  // clone method
+  describe('#clone', () => {
+    it('should clone an existing PipelineStage', done => {
+      const source = pipeline.of(1, 2, 3)
+      const out = pipeline.clone(source)
+      const expected = [1, 2, 3]
+      let cpt = 0
+      out.subscribe(x => {
+        expect(x).to.be.oneOf(expected)
+        // pull out element
+        expected.splice(expected.indexOf(x), 1)
+        cpt++
+      }, done, () => {
+        expect(cpt).to.equal(3)
+        expect(expected.length).to.equal(0)
+        done()
+      })
+    })
+  })
+
+  // merge method
+  describe('#merge', () => {
+    it('should merge two PipelineStage into a single one', done => {
+      const out = pipeline.merge(pipeline.of(1, 2), pipeline.of(3))
+      const expected = [1, 2, 3]
+      let cpt = 0
+      out.subscribe(x => {
+        expect(x).to.be.oneOf(expected)
+        // pull out element
+        expected.splice(expected.indexOf(x), 1)
+        cpt++
+      }, done, () => {
+        expect(cpt).to.equal(3)
+        expect(expected.length).to.equal(0)
+        done()
+      })
+    })
+
+    it('should merge three PipelineStage into a single one', done => {
+      const out = pipeline.merge(pipeline.of(1, 2), pipeline.of(3), pipeline.of(4, 5))
+      const expected = [1, 2, 3, 4, 5]
+      let cpt = 0
+      out.subscribe(x => {
+        expect(x).to.be.oneOf(expected)
+        // pull out element
+        expected.splice(expected.indexOf(x), 1)
+        cpt++
+      }, done, () => {
+        expect(cpt).to.equal(5)
+        expect(expected.length).to.equal(0)
+        done()
+      })
+    })
+  })
+
+  // map method
+  describe('#map', () => {
+    it('should transform items of a PipelineStage', done => {
+      const out = pipeline.map(pipeline.of(1, 2, 3), x => x * 2)
+      const expected = [2, 4, 6]
+      let cpt = 0
+      out.subscribe(x => {
+        expect(x).to.be.oneOf(expected)
+        // pull out element
+        expected.splice(expected.indexOf(x), 1)
+        cpt++
+      }, done, () => {
+        expect(cpt).to.equal(3)
+        expect(expected.length).to.equal(0)
+        done()
+      })
+    })
+  })
+
+  // mergeMap method
+  describe('#mergeMap', () => {
+    it('should transform items of a PipelineStage using PipelineStage that emits one item', done => {
+      const out = pipeline.mergeMap(pipeline.of(1, 2, 3), x => pipeline.of(x * 2))
+      const expected = [2, 4, 6]
+      let cpt = 0
+      out.subscribe(x => {
+        expect(x).to.be.oneOf(expected)
+        // pull out element
+        expected.splice(expected.indexOf(x), 1)
+        cpt++
+      }, done, () => {
+        expect(cpt).to.equal(3)
+        expect(expected.length).to.equal(0)
+        done()
+      })
+    })
+
+    it('should transform items of a PipelineStage using PipelineStage that emits several items', done => {
+      const out = pipeline.mergeMap(pipeline.of(1, 2, 3), x => pipeline.of(x * 2, x * 3))
+      const expected = [2, 4, 6, 3, 6, 9]
+      let cpt = 0
+      out.subscribe(x => {
+        expect(x).to.be.oneOf(expected)
+        // pull out element
+        expected.splice(expected.indexOf(x), 1)
+        cpt++
+      }, done, () => {
+        expect(cpt).to.equal(6)
+        expect(expected.length).to.equal(0)
+        done()
+      })
+    })
+  })
+
+  // flatMap method
+  describe('#flatMap', () => {
+    it('shoudl transform items of a PipelineStage into flattened array of items', done => {
+      const out = pipeline.flatMap(pipeline.of(1, 2, 3), x => [x * 2, x * 3])
+      const expected = [2, 4, 6, 3, 6, 9]
+      let cpt = 0
+      out.subscribe(x => {
+        expect(x).to.be.oneOf(expected)
+        // pull out element
+        expected.splice(expected.indexOf(x), 1)
+        cpt++
+      }, done, () => {
+        expect(cpt).to.equal(6)
+        expect(expected.length).to.equal(0)
+        done()
+      })
+    })
+  })
+
+  // reduce method
+  describe('#reduce', () => {
+    it('should reduce elements emitted by a PipelineStage', done => {
+      const out = pipeline.reduce(pipeline.of(1, 2, 3), (acc, x) => acc + x, 0)
+      let cpt = 0
+      out.subscribe(x => {
+        expect(x).to.equal(6)
+        cpt++
+      }, done, () => {
+        expect(cpt).to.equal(1)
+        done()
+      })
+    })
+
+    it('should reduce elements emitted by an empty PipelineStage into the initial value', done => {
+      const out = pipeline.reduce(pipeline.empty(), (acc, x) => acc + x, 0)
+      let cpt = 0
+      out.subscribe(x => {
+        expect(x).to.equal(0)
+        cpt++
+      }, done, () => {
+        expect(cpt).to.equal(1)
+        done()
+      })
+    })
+  })
+
+  // limit method
+  describe('#limit', () => {
+    it('should limit the output of a PipelineStage', done => {
+      const out = pipeline.limit(pipeline.of(1, 2, 3, 4, 5), 2)
+      const expected = [1, 2, 3, 4, 5]
+      let cpt = 0
+      out.subscribe(x => {
+        expect(x).to.be.oneOf(expected)
+        // pull out element
+        expected.splice(expected.indexOf(x), 1)
+        cpt++
+      }, done, () => {
+        expect(cpt).to.equal(2)
+        expect(expected.length).to.equal(3)
+        done()
+      })
+    })
+
+    it('should limit the output of an empty PipelineStage', done => {
+      const out = pipeline.limit(pipeline.empty(), 2)
+      let cpt = 0
+      out.subscribe(() => {
+        cpt++
+      }, done, () => {
+        expect(cpt).to.equal(0)
+        done()
+      })
+    })
+
+    it('should work if the limit is higher that the number of items emitted by a PipelineStage', done => {
+      const out = pipeline.limit(pipeline.of(1, 2, 3, 4, 5), 12)
+      const expected = [1, 2, 3, 4, 5]
+      let cpt = 0
+      out.subscribe(x => {
+        expect(x).to.be.oneOf(expected)
+        // pull out element
+        expected.splice(expected.indexOf(x), 1)
+        cpt++
+      }, done, () => {
+        expect(cpt).to.equal(5)
+        expect(expected.length).to.equal(0)
+        done()
+      })
+    })
+  })
+
+  // skip method
+  describe('#skip', () => {
+    it('should skip the output of a PipelineStage', done => {
+      const out = pipeline.skip(pipeline.of(1, 2, 3, 4, 5), 2)
+      const expected = [1, 2, 3, 4, 5]
+      let cpt = 0
+      out.subscribe(x => {
+        expect(x).to.be.oneOf(expected)
+        // pull out element
+        expected.splice(expected.indexOf(x), 1)
+        cpt++
+      }, done, () => {
+        expect(cpt).to.equal(3)
+        expect(expected.length).to.equal(2)
+        done()
+      })
+    })
+
+    it('should skip the output of an empty PipelineStage', done => {
+      const out = pipeline.skip(pipeline.empty(), 2)
+      let cpt = 0
+      out.subscribe(() => {
+        cpt++
+      }, done, () => {
+        expect(cpt).to.equal(0)
+        done()
+      })
+    })
+
+    it('should work if the skip is higher that the number of items emitted by a PipelineStage', done => {
+      const out = pipeline.skip(pipeline.of(1, 2, 3, 4, 5), 12)
+      let cpt = 0
+      out.subscribe(() => {
+        cpt++
+      }, done, () => {
+        expect(cpt).to.equal(0)
+        done()
+      })
+    })
+  })
+
+  // distinct method
+  describe('#distinct', () => {
+    it('should remove duplicated elements emitted by a PipelineStage', done => {
+      const out = pipeline.distinct(pipeline.of(1, 1, 2, 2, 3, 3))
+      const expected = [1, 2, 3]
+      let cpt = 0
+      out.subscribe(x => {
+        expect(x).to.be.oneOf(expected)
+        expected.splice(expected.indexOf(x), 1)
+        cpt++
+      }, done, () => {
+        expect(cpt).to.equal(3)
+        expect(expected.length).to.equal(0)
+        done()
+      })
+    })
+
+    it('should remove duplicated elements using a selector function', done => {
+      const out = pipeline.distinct(pipeline.of(1, 2, 3), x => (x === 2) ? 1 : x)
+      const expected = [1, 3]
+      let cpt = 0
+      out.subscribe(x => {
+        expect(x).to.be.oneOf(expected)
+        expected.splice(expected.indexOf(x), 1)
+        cpt++
+      }, done, () => {
+        expect(cpt).to.equal(2)
+        expect(expected.length).to.equal(0)
+        done()
+      })
+    })
+  })
+
+  // forEach method
+  describe('#forEach', () => {
+    it('should invoke a callback on each item emitted by a PipelineStage', done => {
+      let cpt = 0
+      const expected = [1, 2, 3]
+      pipeline.forEach(pipeline.of(1, 2, 3), x => {
+        expect(x).to.be.oneOf(expected)
+        expected.splice(expected.indexOf(x), 1)
+        cpt++
+        if (cpt === 3) {
+          expect(expected.length).to.equal(0)
+          done()
+        }
+      })
+    })
+  })
+
+  // defaultValues method
+  describe('#defaultValues', () => {
+    it('should set a (single) default for an empty PipelineStage', done => {
+      const out = pipeline.defaultValues(pipeline.empty(), 1)
+      let cpt = 0
+      out.subscribe(x => {
+        expect(x).to.equal(1)
+        cpt++
+      }, done, () => {
+        expect(cpt).to.equal(1)
+        done()
+      })
+    })
+
+    it('should set several default values for an empty PipelineStage', done => {
+      const out = pipeline.defaultValues(pipeline.empty(), 1, 2, 3)
+      const expected = [1, 2, 3]
+      let cpt = 0
+      out.subscribe(x => {
+        expect(x).to.be.oneOf(expected)
+        expected.splice(expected.indexOf(x), 1)
+        cpt++
+      }, done, () => {
+        expect(cpt).to.equal(3)
+        expect(expected.length).to.equal(0)
+        done()
+      })
+    })
+  })
+
+  // bufferCount method
+  describe('#bufferCount', () => {
+    it('should buffer items emitted by a PipelineStage', done => {
+      const out = pipeline.bufferCount(pipeline.of(1, 2, 3, 4), 2)
+      const expected = [1, 2, 3, 4]
+      let cpt = 0
+      out.subscribe(chunk => {
+        expect(chunk.length).to.equal(2)
+        chunk.forEach(x => {
+          expect(x).to.be.oneOf(expected)
+          expected.splice(expected.indexOf(x), 1)
+          cpt++
+        })
+      }, done, () => {
+        expect(cpt).to.equal(4)
+        expect(expected.length).to.equal(0)
+        done()
+      })
+    })
+
+    it('should buffer items even if the buffer size is higher that the total number of items produced', done => {
+      const out = pipeline.bufferCount(pipeline.of(1, 2, 3, 4), 5)
+      const expected = [1, 2, 3, 4]
+      let cpt = 0
+      out.subscribe(chunk => {
+        expect(chunk.length).to.equal(4)
+        chunk.forEach(x => {
+          expect(x).to.be.oneOf(expected)
+          expected.splice(expected.indexOf(x), 1)
+          cpt++
+        })
+      }, done, () => {
+        expect(cpt).to.equal(4)
+        expect(expected.length).to.equal(0)
+        done()
+      })
+    })
+  })
+
+  // collect method
+  describe('#collect', () => {
+    it('should collect all values emitted by a PipelineStage as an array', done => {
+      const out = pipeline.collect(pipeline.of(1, 2, 3, 4))
+      const expected = [1, 2, 3, 4]
+      let cpt = 0
+      out.subscribe(chunk => {
+        expect(chunk.length).to.equal(4)
+        chunk.forEach(x => {
+          expect(x).to.be.oneOf(expected)
+          expected.splice(expected.indexOf(x), 1)
+        })
+        cpt++
+      }, done, () => {
+        expect(cpt).to.equal(1)
+        expect(expected.length).to.equal(0)
+        done()
+      })
+    })
+
+    it('should produce an empty array when applied to an empty PipelineStage', done => {
+      const out = pipeline.collect(pipeline.empty())
+      let cpt = 0
+      out.subscribe(chunk => {
+        expect(chunk.length).to.equal(0)
+        cpt++
+      }, done, () => {
+        expect(cpt).to.equal(1)
+        done()
+      })
+    })
+  })
+}
+
+module.exports = testPipelineEngine

--- a/tests/pipeline/fixtures.js
+++ b/tests/pipeline/fixtures.js
@@ -510,6 +510,72 @@ function testPipelineEngine (pipeline) {
       })
     })
   })
+
+  // first method
+  describe('#first', () => {
+    it('should emit the first item of the PipelineStage', done => {
+      const out = pipeline.first(pipeline.of(1, 2))
+      let cpt = 0
+      out.subscribe(x => {
+        expect(x).to.be.oneOf([1, 2])
+        cpt++
+      }, done, () => {
+        expect(cpt).to.equal(1)
+        done()
+      })
+    })
+  })
+
+  // endWith method
+  describe('#endsWith', () => {
+    it('should append items at the end of the PipelineStage', done => {
+      const out = pipeline.endWith(pipeline.empty(), [1, 2, 3, 4])
+      const expected = [1, 2, 3, 4]
+      let cpt = 0
+      out.subscribe(x => {
+        expect(x).to.be.oneOf(expected)
+        expected.splice(expected.indexOf(x), 1)
+        cpt++
+      }, done, () => {
+        expect(cpt).to.equal(4)
+        expect(expected.length).to.equal(0)
+        done()
+      })
+    })
+  })
+
+  // tap method
+  describe('#tap', () => {
+    it('should invoke a function on each item in a PipelineStage, then forward the item', done => {
+      let nbTaps = 0
+      const out = pipeline.tap(pipeline.of(1, 2, 3, 4), () => nbTaps++)
+      const expected = [1, 2, 3, 4]
+      let cpt = 0
+      out.subscribe(x => {
+        expect(x).to.be.oneOf(expected)
+        expected.splice(expected.indexOf(x), 1)
+        cpt++
+      }, done, () => {
+        expect(cpt).to.equal(4)
+        expect(nbTaps).to.equal(4)
+        expect(expected.length).to.equal(0)
+        done()
+      })
+    })
+
+    it('should not invoke the function when applied to an empty PipelineStage', done => {
+      let nbTaps = 0
+      const out = pipeline.tap(pipeline.empty(), () => nbTaps++)
+      let cpt = 0
+      out.subscribe(() => {
+        cpt++
+      }, done, () => {
+        expect(cpt).to.equal(0)
+        expect(nbTaps).to.equal(0)
+        done()
+      })
+    })
+  })
 }
 
 module.exports = testPipelineEngine

--- a/tests/pipeline/rxjs-pipeline-test.js
+++ b/tests/pipeline/rxjs-pipeline-test.js
@@ -1,0 +1,33 @@
+/* file : rxjs-pipeline-test.js
+MIT License
+
+Copyright (c) 2019 Thomas Minier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+'use strict'
+
+const testPipelineEngine = require('./fixtures.js')
+const RxjsPipeline = require('../../dist/engine/pipeline/rxjs-pipeline.js').default
+
+describe('RxjsPipeline', () => {
+  const pipeline = new RxjsPipeline()
+  testPipelineEngine(pipeline)
+})

--- a/tests/pipeline/vector-pipeline-test.js
+++ b/tests/pipeline/vector-pipeline-test.js
@@ -1,0 +1,33 @@
+/* file : vector-pipeline-test.js
+MIT License
+
+Copyright (c) 2019 Thomas Minier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+'use strict'
+
+const testPipelineEngine = require('./fixtures.js')
+const VectorPipeline = require('../../dist/engine/pipeline/vector-pipeline.js').default
+
+describe('VectorPipeline', () => {
+  const pipeline = new VectorPipeline()
+  testPipelineEngine(pipeline)
+})


### PR DESCRIPTION
Implements the functionalities discusses in #15 
**WARNING:** this PR introduces major changes to almost every class in the framework, so it will likely break all existing forks.

The changes are:
* All the pipeline-related operations are now abstracted using `PipelineEngine`.
* Subclasses of `PipelineEngine` are used to execute every operation in the main query engine, which **removes the strong coupling to `rxjs`**.
* `RxjsPipeline` is a subclass of `PipelineEngine` which implements the pipeline operations using `rxjs`. It corresponds to the engine behaviour before this PR. `RxjsPipeline` is used as the default pipeline implementation.
* `VectorPiepline` is a subclass of `PipelineEngine` which follows the vectorization paradigm: all intermediate results are materialized in main memory. This pipeline impl. is more efficient CPU-wise, but consume more memory.
* Added a configurable test suite to test all subclasses of `PipelineEngine`. 
* Update the README with a short tutorial on these new functionalities.