### PR TITLE
fixes issue #16

### DIFF
--- a/src/operators/minus.ts
+++ b/src/operators/minus.ts
@@ -52,7 +52,7 @@ export default function minus (leftSource: PipelineStage<Bindings>, rightSource:
         return commonKeys.every((k: string) => b.get(k) === bindings.get(k))
       })
       // only output non-compatible bindings
-    return !isCompatible
+      return !isCompatible
     })
   })
 }

--- a/src/operators/sparql-filter.ts
+++ b/src/operators/sparql-filter.ts
@@ -29,7 +29,7 @@ import { PipelineStage } from '../engine/pipeline/pipeline-engine'
 import SPARQLExpression from './expressions/sparql-expression'
 import { Algebra } from 'sparqljs'
 import { Bindings } from '../rdf/bindings'
-import { CustomFunctions } from "../engine/plan-builder"
+import { CustomFunctions } from '../engine/plan-builder'
 
 /**
  * Evaluate SPARQL Filter clauses

--- a/src/operators/sparql-groupby.ts
+++ b/src/operators/sparql-groupby.ts
@@ -77,26 +77,26 @@ export default function sparqlGroupBy (source: PipelineStage<Bindings>, variable
   let op = engine.map(source, (bindings: Bindings) => {
     const key = _hashBindings(variables, bindings)
       // create a new group is needed
-      if (!groups.has(key)) {
+    if (!groups.has(key)) {
         keys.set(key, bindings.filter(variable => variables.indexOf(variable) > -1))
         groups.set(key, buildNewGroup(Array.from(bindings.variables())))
       }
       // parse each binding in the intermediate format used by SPARQL expressions
       // and insert it into the corresponding group
-      bindings.forEach((variable, value) => {
+    bindings.forEach((variable, value) => {
         groups.get(key)[variable].push(rdf.parseTerm(value))
       })
-      return null
+    return null
   })
   return engine.mergeMap(engine.collect(op), () => {
     const aggregates: any[] = []
       // transform each group in a set of bindings
-      groups.forEach((group, key) => {
+    groups.forEach((group, key) => {
         // also add the GROUP BY keys to the set of bindings
         const b = keys.get(key)!.clone()
         b.setProperty('__aggregate', group)
         aggregates.push(b)
       })
-      return engine.from(aggregates)
+    return engine.from(aggregates)
   })
 }

--- a/src/optimizer/optimizer.ts
+++ b/src/optimizer/optimizer.ts
@@ -35,7 +35,7 @@ import UnionMerge from './visitors/union-merge'
 export default class Optimizer {
   private _visitors: PlanVisitor[]
 
-  constructor() {
+  constructor () {
     this._visitors = []
   }
 
@@ -43,7 +43,7 @@ export default class Optimizer {
    * Get an optimizer configured with the default optimization rules
    * @return A new Optimizer pre-configured with default rules
    */
-  static getDefault(): Optimizer {
+  static getDefault (): Optimizer {
     const opt = new Optimizer()
     opt.addVisitor(new UnionMerge())
     return opt
@@ -53,7 +53,7 @@ export default class Optimizer {
    * Register a new visitor, which implements an optimization rule.
    * @param visitor - Visitor
    */
-  addVisitor(visitor: PlanVisitor): void {
+  addVisitor (visitor: PlanVisitor): void {
     this._visitors.push(visitor)
   }
 
@@ -62,7 +62,7 @@ export default class Optimizer {
    * @param  plan - SPARQL query expression tree to iptimize
    * @return Optimized SPARQL query expression tree
    */
-  optimize(plan: Algebra.PlanNode): Algebra.PlanNode {
+  optimize (plan: Algebra.PlanNode): Algebra.PlanNode {
     return this._visitors.reduce((current, v) => v.visit(current), plan)
   }
 }

--- a/src/optimizer/plan-visitor.ts
+++ b/src/optimizer/plan-visitor.ts
@@ -40,8 +40,8 @@ export default class PlanVisitor {
    * @param  node - Root of the expression tree to traverse
    * @return The transformed expression tree
    */
-  visit(node: Algebra.PlanNode): Algebra.PlanNode {
-    switch(node.type) {
+  visit (node: Algebra.PlanNode): Algebra.PlanNode {
+    switch (node.type) {
       case 'query':
         const newNode = cloneDeep(node) as Algebra.RootNode
         newNode.where = (node as Algebra.RootNode).where.map(n => this.visit(n))
@@ -73,7 +73,7 @@ export default class PlanVisitor {
    * @param  node - Basic Graph Pattern node
    * @return The transformed Basic Graph Pattern node
    */
-  visitBGP(node: Algebra.BGPNode): Algebra.PlanNode {
+  visitBGP (node: Algebra.BGPNode): Algebra.PlanNode {
     return node
   }
 
@@ -83,7 +83,7 @@ export default class PlanVisitor {
    * @param  node - SPARQL Group pattern node
    * @return The transformed SPARQL Group pattern node
    */
-  visitGroup(node: Algebra.GroupNode): Algebra.PlanNode {
+  visitGroup (node: Algebra.GroupNode): Algebra.PlanNode {
     const newNode = cloneDeep(node)
     newNode.patterns = newNode.patterns.map(p => this.visit(p))
     return newNode
@@ -95,7 +95,7 @@ export default class PlanVisitor {
    * @param  node - SPARQL OPTIONAL node
    * @return The transformed SPARQL OPTIONAL node
    */
-  visitOptional(node: Algebra.GroupNode): Algebra.PlanNode {
+  visitOptional (node: Algebra.GroupNode): Algebra.PlanNode {
     const newNode = cloneDeep(node)
     newNode.patterns = newNode.patterns.map(p => this.visit(p))
     return newNode
@@ -107,7 +107,7 @@ export default class PlanVisitor {
    * @param  node - SPARQL UNION node
    * @return The transformed SPARQL UNION node
    */
-  visitUnion(node: Algebra.GroupNode): Algebra.PlanNode {
+  visitUnion (node: Algebra.GroupNode): Algebra.PlanNode {
     const newNode = cloneDeep(node)
     newNode.patterns = newNode.patterns.map(p => this.visit(p))
     return newNode
@@ -119,7 +119,7 @@ export default class PlanVisitor {
    * @param  node - SPARQL FILTER node
    * @return The transformed SPARQL FILTER node
    */
-  visitFilter(node: Algebra.FilterNode): Algebra.PlanNode {
+  visitFilter (node: Algebra.FilterNode): Algebra.PlanNode {
     return node
   }
 
@@ -129,7 +129,7 @@ export default class PlanVisitor {
    * @param  node - SPARQL GRAPH node
    * @return The transformed SPARQL GRAPH node
    */
-  visitGraph(node: Algebra.GraphNode): Algebra.PlanNode {
+  visitGraph (node: Algebra.GraphNode): Algebra.PlanNode {
     const newNode = cloneDeep(node)
     newNode.patterns = newNode.patterns.map(p => this.visit(p))
     return newNode
@@ -141,7 +141,7 @@ export default class PlanVisitor {
    * @param  node - SPARQL SERVICE node
    * @return The transformed SPARQL SERVICE node
    */
-  visitService(node: Algebra.ServiceNode): Algebra.PlanNode {
+  visitService (node: Algebra.ServiceNode): Algebra.PlanNode {
     const newNode = cloneDeep(node)
     newNode.patterns = newNode.patterns.map(p => this.visit(p))
     return newNode
@@ -153,7 +153,7 @@ export default class PlanVisitor {
    * @param  node - SPARQL BIND node
    * @return The transformed SPARQL BIND node
    */
-  visitBind(node: Algebra.BindNode): Algebra.PlanNode {
+  visitBind (node: Algebra.BindNode): Algebra.PlanNode {
     return node
   }
 
@@ -163,7 +163,7 @@ export default class PlanVisitor {
    * @param  node - SPARQL VALUES node
    * @return The transformed SPARQL VALUES node
    */
-  visitValues(node: Algebra.ValuesNode): Algebra.PlanNode {
+  visitValues (node: Algebra.ValuesNode): Algebra.PlanNode {
     return node
   }
 }

--- a/src/rdf-terms.ts
+++ b/src/rdf-terms.ts
@@ -249,9 +249,9 @@ export namespace terms {
   export function replaceLiteralValue (term: RDFTerm, newValue: string): RDFTerm {
     switch (term.type) {
       case 'literal+type':
-        return createTypedLiteral(newValue, (<TypedLiteral> term).datatype)
+        return createTypedLiteral(newValue, (term as TypedLiteral).datatype)
       case 'literal+lang':
-        return createLangLiteral(newValue, (<LangLiteral> term).lang)
+        return createLangLiteral(newValue, (term as LangLiteral).lang)
       default:
         return createLiteral(newValue)
     }
@@ -273,9 +273,9 @@ export namespace terms {
       case 'literal':
         return createBoolean(left.value === right.value)
       case 'literal+type':
-        return createBoolean(left.value === right.value && (<TypedLiteral> left).datatype === (<TypedLiteral> right).datatype)
+        return createBoolean(left.value === right.value && (left as TypedLiteral).datatype === (right as TypedLiteral).datatype)
       case 'literal+lang':
-        return createBoolean(left.value === right.value && (<LangLiteral> left).lang === (<LangLiteral> right).lang)
+        return createBoolean(left.value === right.value && (left as LangLiteral).lang === (right as LangLiteral).lang)
       default:
         return createBoolean(false)
     }
@@ -323,7 +323,7 @@ export namespace terms {
    * @return True if the term is a Date literal, False otherwise
    */
   export function isDate (literal: RDFTerm): boolean {
-      return literal.type === 'literal+type' && (<TypedLiteral> literal).datatype === rdf.XSD('dateTime')
+    return literal.type === 'literal+type' && (literal as TypedLiteral).datatype === rdf.XSD('dateTime')
   }
 
   /**
@@ -332,11 +332,11 @@ export namespace terms {
    * @return True if the term is a Number literal, False otherwise
    */
   export function isNumber (term: RDFTerm): boolean {
-      if (term.type !== 'literal+type') {
-        return false;
+    if (term.type !== 'literal+type') {
+        return false
       }
-      const literal: TypedLiteral = term as TypedLiteral
-      switch (literal.type) {
+    const literal: TypedLiteral = term as TypedLiteral
+    switch (literal.type) {
         case rdf.XSD('integer'):
         case rdf.XSD('byte'):
         case rdf.XSD('short'):
@@ -354,9 +354,9 @@ export namespace terms {
         case rdf.XSD('nonPositiveInteger'):
         case rdf.XSD('negativeInteger'):
         case rdf.XSD('nonNegativeInteger'):
-          return true;
+          return true
         default:
-          return false;
+          return false
       }
   }
 }

--- a/src/rdf/dataset.ts
+++ b/src/rdf/dataset.ts
@@ -33,7 +33,7 @@ import UnionGraph from './union-graph'
  * @author Thomas Minier
  */
 export default abstract class Dataset {
-  private _graphFactory: (iri: string) => Graph | null;
+  private _graphFactory: (iri: string) => Graph | null
 
   /**
    * Constructor
@@ -41,7 +41,6 @@ export default abstract class Dataset {
   constructor () {
     this._graphFactory = () => null
   }
-
 
   abstract get iris (): string[]
   /**

--- a/src/rdf/graph.ts
+++ b/src/rdf/graph.ts
@@ -188,5 +188,5 @@ export default abstract class Graph {
 }
 
 // disable optional methods
-Object.defineProperty(Graph.prototype, 'estimateCardinality', {value: null})
-Object.defineProperty(Graph.prototype, 'evalUnion', {value: null})
+Object.defineProperty(Graph.prototype, 'estimateCardinality', { value: null })
+Object.defineProperty(Graph.prototype, 'evalUnion', { value: null })

--- a/tests/sparql/graph-test.js
+++ b/tests/sparql/graph-test.js
@@ -22,26 +22,26 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
-'use strict'
+"use strict";
 
-const expect = require('chai').expect
-const { getGraph, TestEngine } = require('../utils.js')
+const expect = require("chai").expect;
+const { getGraph, TestEngine } = require("../utils.js");
 
-const GRAPH_A_IRI = 'http://example.org#some-graph-a'
-const GRAPH_B_IRI = 'http://example.org#some-graph-b'
+const GRAPH_A_IRI = "http://example.org#some-graph-a";
+const GRAPH_B_IRI = "http://example.org#some-graph-b";
 
-describe('GRAPH/FROM queries', () => {
-  let engine = null
+describe("GRAPH/FROM queries", () => {
+  let engine = null;
   beforeEach(() => {
-    const gA = getGraph('./tests/data/dblp.nt')
-    const gB = getGraph('./tests/data/dblp2.nt')
-    engine = new TestEngine(gA, GRAPH_A_IRI)
-    engine.addNamedGraph(GRAPH_B_IRI, gB)
-  })
+    const gA = getGraph("./tests/data/dblp.nt");
+    const gB = getGraph("./tests/data/dblp2.nt");
+    engine = new TestEngine(gA, GRAPH_A_IRI);
+    engine.addNamedGraph(GRAPH_B_IRI, gB);
+  });
 
   const data = [
     {
-      text: 'should evaluate a query with one FROM clause',
+      text: "should evaluate a query with one FROM clause",
       query: `
       PREFIX dblp-pers: <https://dblp.org/pers/m/>
       PREFIX dblp-rdf: <https://dblp.uni-trier.de/rdf/schema-2017-04-18#>
@@ -54,15 +54,18 @@ describe('GRAPH/FROM queries', () => {
         ?s dblp-rdf:authorOf ?article .
       }`,
       nbResults: 2,
-      testFun: function (b) {
-        expect(b).to.have.all.keys(['?s', '?name', '?article'])
-        expect(b['?s']).to.equal('https://dblp.org/pers/g/Grall:Arnaud')
-        expect(b['?name']).to.equal('"Arnaud Grall"')
-        expect(b['?article']).to.be.oneOf(['https://dblp.org/rec/conf/semweb/GrallSM18', 'https://dblp.org/rec/conf/esws/GrallFMSMSV17'])
+      testFun: function(b) {
+        expect(b).to.have.all.keys(["?s", "?name", "?article"]);
+        expect(b["?s"]).to.equal("https://dblp.org/pers/g/Grall:Arnaud");
+        expect(b["?name"]).to.equal('"Arnaud Grall"');
+        expect(b["?article"]).to.be.oneOf([
+          "https://dblp.org/rec/conf/semweb/GrallSM18",
+          "https://dblp.org/rec/conf/esws/GrallFMSMSV17"
+        ]);
       }
     },
     {
-      text: 'should evaluate a query with several FROM clauses',
+      text: "should evaluate a query with several FROM clauses",
       query: `
       PREFIX dblp-pers: <https://dblp.org/pers/m/>
       PREFIX dblp-rdf: <https://dblp.uni-trier.de/rdf/schema-2017-04-18#>
@@ -76,32 +79,35 @@ describe('GRAPH/FROM queries', () => {
         ?s dblp-rdf:authorOf ?article .
       }`,
       nbResults: 7,
-      testFun: function (b) {
-        expect(b).to.have.all.keys(['?s', '?name', '?article'])
-        switch (b['?s']) {
-          case 'https://dblp.org/pers/g/Grall:Arnaud':
-            expect(b['?s']).to.equal('https://dblp.org/pers/g/Grall:Arnaud')
-            expect(b['?name']).to.equal('"Arnaud Grall"')
-            expect(b['?article']).to.be.oneOf(['https://dblp.org/rec/conf/semweb/GrallSM18', 'https://dblp.org/rec/conf/esws/GrallFMSMSV17'])
-            break
-          case 'https://dblp.org/pers/m/Minier:Thomas':
-            expect(b['?s']).to.equal('https://dblp.org/pers/m/Minier:Thomas')
-            expect(b['?name']).to.equal('"Thomas Minier"@en')
-            expect(b['?article']).to.be.oneOf([
-              'https://dblp.org/rec/conf/esws/MinierSMV18a',
-              'https://dblp.org/rec/conf/esws/MinierSMV18',
-              'https://dblp.org/rec/journals/corr/abs-1806-00227',
-              'https://dblp.org/rec/conf/esws/MinierMSM17',
-              'https://dblp.org/rec/conf/esws/MinierMSM17a'
-            ])
-            break
+      testFun: function(b) {
+        expect(b).to.have.all.keys(["?s", "?name", "?article"]);
+        switch (b["?s"]) {
+          case "https://dblp.org/pers/g/Grall:Arnaud":
+            expect(b["?s"]).to.equal("https://dblp.org/pers/g/Grall:Arnaud");
+            expect(b["?name"]).to.equal('"Arnaud Grall"');
+            expect(b["?article"]).to.be.oneOf([
+              "https://dblp.org/rec/conf/semweb/GrallSM18",
+              "https://dblp.org/rec/conf/esws/GrallFMSMSV17"
+            ]);
+            break;
+          case "https://dblp.org/pers/m/Minier:Thomas":
+            expect(b["?s"]).to.equal("https://dblp.org/pers/m/Minier:Thomas");
+            expect(b["?name"]).to.equal('"Thomas Minier"@en');
+            expect(b["?article"]).to.be.oneOf([
+              "https://dblp.org/rec/conf/esws/MinierSMV18a",
+              "https://dblp.org/rec/conf/esws/MinierSMV18",
+              "https://dblp.org/rec/journals/corr/abs-1806-00227",
+              "https://dblp.org/rec/conf/esws/MinierMSM17",
+              "https://dblp.org/rec/conf/esws/MinierMSM17a"
+            ]);
+            break;
           default:
-            throw new Error(`Unexpected ?s binding found ${b['?s']}`)
+            throw new Error(`Unexpected ?s binding found ${b["?s"]}`);
         }
       }
     },
     {
-      text: 'should evaluate simple SPARQL GRAPH queries',
+      text: "should evaluate simple SPARQL GRAPH queries",
       query: `
       PREFIX dblp-pers: <https://dblp.org/pers/m/>
       PREFIX dblp-rdf: <https://dblp.uni-trier.de/rdf/schema-2017-04-18#>
@@ -114,20 +120,20 @@ describe('GRAPH/FROM queries', () => {
         }
       }`,
       nbResults: 3,
-      testFun: function (b) {
-        expect(b).to.have.all.keys(['?s', '?s2', '?coCreator', '?name'])
-        expect(b['?s']).to.equal('https://dblp.org/pers/m/Minier:Thomas')
-        expect(b['?s2']).to.equal('https://dblp.org/pers/g/Grall:Arnaud')
-        expect(b['?name']).to.equal('"Arnaud Grall"')
-        expect(b['?coCreator']).to.be.oneOf([
-          'https://dblp.org/pers/m/Molli:Pascal',
-          'https://dblp.org/pers/m/Montoya:Gabriela',
-          'https://dblp.org/pers/s/Skaf=Molli:Hala'
-        ])
+      testFun: function(b) {
+        expect(b).to.have.all.keys(["?s", "?s2", "?coCreator", "?name"]);
+        expect(b["?s"]).to.equal("https://dblp.org/pers/m/Minier:Thomas");
+        expect(b["?s2"]).to.equal("https://dblp.org/pers/g/Grall:Arnaud");
+        expect(b["?name"]).to.equal('"Arnaud Grall"');
+        expect(b["?coCreator"]).to.be.oneOf([
+          "https://dblp.org/pers/m/Molli:Pascal",
+          "https://dblp.org/pers/m/Montoya:Gabriela",
+          "https://dblp.org/pers/s/Skaf=Molli:Hala"
+        ]);
       }
     },
     {
-      text: 'should evaluate SPARQL GRAPH with FROM NAMED clauses',
+      text: "should evaluate SPARQL GRAPH with FROM NAMED clauses",
       query: `
       PREFIX dblp-pers: <https://dblp.org/pers/m/>
       PREFIX dblp-rdf: <https://dblp.uni-trier.de/rdf/schema-2017-04-18#>
@@ -142,33 +148,66 @@ describe('GRAPH/FROM queries', () => {
         }
       }`,
       nbResults: 3,
-      testFun: function (b) {
-        expect(b).to.have.all.keys(['?s', '?s2', '?coCreator', '?name', '?g'])
-        expect(b['?s']).to.equal('https://dblp.org/pers/m/Minier:Thomas')
-        expect(b['?s2']).to.equal('https://dblp.org/pers/g/Grall:Arnaud')
-        expect(b['?g']).to.be.oneOf([ GRAPH_A_IRI, GRAPH_B_IRI ])
-        expect(b['?name']).to.equal('"Arnaud Grall"')
-        expect(b['?coCreator']).to.be.oneOf([
-          'https://dblp.org/pers/m/Molli:Pascal',
-          'https://dblp.org/pers/m/Montoya:Gabriela',
-          'https://dblp.org/pers/s/Skaf=Molli:Hala'
-        ])
+      testFun: function(b) {
+        expect(b).to.have.all.keys(["?s", "?s2", "?coCreator", "?name", "?g"]);
+        expect(b["?s"]).to.equal("https://dblp.org/pers/m/Minier:Thomas");
+        expect(b["?s2"]).to.equal("https://dblp.org/pers/g/Grall:Arnaud");
+        expect(b["?g"]).to.be.oneOf([GRAPH_A_IRI, GRAPH_B_IRI]);
+        expect(b["?name"]).to.equal('"Arnaud Grall"');
+        expect(b["?coCreator"]).to.be.oneOf([
+          "https://dblp.org/pers/m/Molli:Pascal",
+          "https://dblp.org/pers/m/Montoya:Gabriela",
+          "https://dblp.org/pers/s/Skaf=Molli:Hala"
+        ]);
+      }
+    },
+    {
+      text: "should evaluate SPARQL GRAPH with the name bound in a variable",
+      query: `
+      PREFIX dblp-pers: <https://dblp.org/pers/m/>
+      PREFIX dblp-rdf: <https://dblp.uni-trier.de/rdf/schema-2017-04-18#>
+      PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+      SELECT *
+      WHERE {
+        BIND(<${GRAPH_B_IRI}> as ?g) .
+        ?s dblp-rdf:coCreatorWith ?coCreator .
+        GRAPH ?g {
+          ?s2 dblp-rdf:coCreatorWith ?coCreator .
+          ?s2 dblp-rdf:primaryFullPersonName ?name .
+        }
+      }`,
+      nbResults: 3,
+      testFun: function(b) {
+        expect(b).to.have.all.keys(["?s", "?s2", "?coCreator", "?name", "?g"]);
+        expect(b["?s"]).to.equal("https://dblp.org/pers/m/Minier:Thomas");
+        expect(b["?s2"]).to.equal("https://dblp.org/pers/g/Grall:Arnaud");
+        expect(b["?g"]).to.be.oneOf([GRAPH_A_IRI, GRAPH_B_IRI]);
+        expect(b["?name"]).to.equal('"Arnaud Grall"');
+        expect(b["?coCreator"]).to.be.oneOf([
+          "https://dblp.org/pers/m/Molli:Pascal",
+          "https://dblp.org/pers/m/Montoya:Gabriela",
+          "https://dblp.org/pers/s/Skaf=Molli:Hala"
+        ]);
       }
     }
-  ]
+  ];
 
   data.forEach(d => {
     it(d.text, done => {
-      let nbResults = 0
-      const iterator = engine.execute(d.query)
-      iterator.subscribe(b => {
-        b = b.toObject()
-        d.testFun(b)
-        nbResults++
-      }, done, () => {
-        expect(nbResults).to.equal(d.nbResults)
-        done()
-      })
-    })
-  })
-})
+      let nbResults = 0;
+      const iterator = engine.execute(d.query);
+      iterator.subscribe(
+        b => {
+          b = b.toObject();
+          d.testFun(b);
+          nbResults++;
+        },
+        done,
+        () => {
+          expect(nbResults).to.equal(d.nbResults);
+          done();
+        }
+      );
+    });
+  });
+});


### PR DESCRIPTION
This PR fixes #16, when the name for a GRAPH clause is bound in a variable. The method is to go through binding, by binding looking for the bound variable, and pulling the related graph from the dataset or creating one using the dataset's graph factory if one is set. The search for the variable is only done if the graph's name is a varaible - otherwise the existing method is followed. 