### PR TITLE
Update rdf-terms

### DIFF
--- a/src/rdf-terms.ts
+++ b/src/rdf-terms.ts
@@ -24,7 +24,7 @@ SOFTWARE.
 
 'use strict'
 
-import { parseZone, Moment } from 'moment'
+import { parseZone, Moment, ISO_8601 } from 'moment'
 import { rdf } from './utils'
 
 /**
@@ -61,7 +61,7 @@ function literalToJS (value: string, type: string): any {
     case rdf.XSD('date'):
     case rdf.XSD('time'):
     case rdf.XSD('duration'):
-      return parseZone(value)
+      return parseZone(value, ISO_8601)
     case rdf.XSD('hexBinary'):
       return Buffer.from(value, 'hex')
     case rdf.XSD('base64Binary'):


### PR DESCRIPTION
As a solution for fixing the moment deprecation warning on dates: 
```bash
Deprecation warning: value provided is not in a recognized RFC2822 or ISO format. moment construction falls back to js Date(), which is not reliable across all browsers and versions. Non RFC2822/ISO date formats are discouraged and will be removed in an upcoming major release. Please refer to http://momentjs.com/guides/#/warnings/js-date/ for more info.
Arguments:
[0] _isAMomentObject: true, _isUTC: false, _useUTC: false, _l: undefined, _i: 2017-02-9T00:00:00.0000000Z, _f: undefined, _strict: undefined, _locale: [object Object]
Error
    at Function.createFromInputFallback (/Users/grall-a/Documents/github/sage-fed/node_modules/moment/moment.js:320:98)
    at configFromString (/Users/grall-a/Documents/github/sage-fed/node_modules/moment/moment.js:2385:15)
    at configFromInput (/Users/grall-a/Documents/github/sage-fed/node_modules/moment/moment.js:2611:13)
    at prepareConfig (/Users/grall-a/Documents/github/sage-fed/node_modules/moment/moment.js:2594:13)
    at createFromConfig (/Users/grall-a/Documents/github/sage-fed/node_modules/moment/moment.js:2561:44)
    at createLocalOrUTC (/Users/grall-a/Documents/github/sage-fed/node_modules/moment/moment.js:2648:16)
    at createLocal (/Users/grall-a/Documents/github/sage-fed/node_modules/moment/moment.js:2652:16)
    at Function.createInZone [as parseZone] (/Users/grall-a/Documents/github/sage-fed/node_modules/moment/moment.js:4006:28)
    at literalToJS (/Users/grall-a/Documents/github/sage-fed/node_modules/sparql-engine/dist/rdf-terms.js:62:29)
    at Object.createTypedLiteral (/Users/grall-a/Documents/github/sage-fed/node_modules/sparql-engine/dist/rdf-terms.js:120:19)
```

I added the ISO 8601 (https://en.wikipedia.org/wiki/ISO_8601) standard as second argument that removes this unexpected behavior.
Tested locally. Works perfectly.

For details about special formats: https://momentjs.com/docs/#/parsing/special-formats/