### PR TITLE
Support for all DISTINCT aggregates based on pre-defined aggregates

### DIFF
--- a/src/operators/expressions/sparql-aggregates.ts
+++ b/src/operators/expressions/sparql-aggregates.ts
@@ -44,7 +44,18 @@ export default {
     }
     return terms.createNumber(count, rdf.XSD('integer'))
   },
-
+  'count-distinct': function (variable: string, rows: Object[]): terms.RDFTerm {
+    let map: Map<string, string> = new Map()
+    let count: number = 0
+    if (variable in rows) {
+      rows[variable].forEach((row: Object) => {
+        const hash = JSON.stringify(row)
+        map.set(hash, hash)
+      })
+      count = map.size
+    }
+    return terms.createNumber(count, rdf.XSD('integer'))
+  },
   'sum': function (variable: string, rows: Object[]): terms.RDFTerm {
     let sum = 0
     if (variable in rows) {

--- a/src/operators/expressions/sparql-aggregates.ts
+++ b/src/operators/expressions/sparql-aggregates.ts
@@ -40,19 +40,7 @@ export default {
   'count': function (variable: string, rows: Object[]): terms.RDFTerm {
     let count: number = 0
     if (variable in rows) {
-      count = rows[variable].map((v: string[]) => v !== null).length
-    }
-    return terms.createNumber(count, rdf.XSD('integer'))
-  },
-  'count-distinct': function (variable: string, rows: Object[]): terms.RDFTerm {
-    let map: Map<string, string> = new Map()
-    let count: number = 0
-    if (variable in rows) {
-      rows[variable].forEach((row: Object) => {
-        const hash = JSON.stringify(row)
-        map.set(hash, hash)
-      })
-      count = map.size
+      count = rows[variable].map((v: terms.RDFTerm) => v !== null).length
     }
     return terms.createNumber(count, rdf.XSD('integer'))
   },

--- a/src/operators/expressions/sparql-expression.ts
+++ b/src/operators/expressions/sparql-expression.ts
@@ -101,6 +101,9 @@ export default class SPARQLExpression {
       if (!(aggExpression.aggregation! in SPARQL_AGGREGATES)) {
         throw new Error(`Unsupported SPARQL aggregation: ${aggExpression.aggregation}`)
       }
+      if (aggExpression.distinct) {
+        aggExpression.aggregation += '-distinct'
+      }
       const aggregation = SPARQL_AGGREGATES[aggExpression.aggregation]
       return (bindings: Bindings) => {
         if (bindings.hasProperty('__aggregate')) {

--- a/src/operators/expressions/sparql-expression.ts
+++ b/src/operators/expressions/sparql-expression.ts
@@ -28,7 +28,7 @@ import SPARQL_AGGREGATES from './sparql-aggregates'
 import SPARQL_OPERATIONS from './sparql-operations'
 import { terms } from '../../rdf-terms'
 import { rdf } from '../../utils'
-import { isArray, isString } from 'lodash'
+import { isArray, isString, uniqBy } from 'lodash'
 import { Algebra } from 'sparqljs'
 import { Bindings } from '../../rdf/bindings'
 import { CustomFunctions } from '../../engine/plan-builder'
@@ -101,13 +101,15 @@ export default class SPARQLExpression {
       if (!(aggExpression.aggregation! in SPARQL_AGGREGATES)) {
         throw new Error(`Unsupported SPARQL aggregation: ${aggExpression.aggregation}`)
       }
-      if (aggExpression.distinct) {
-        aggExpression.aggregation += '-distinct'
-      }
       const aggregation = SPARQL_AGGREGATES[aggExpression.aggregation]
       return (bindings: Bindings) => {
         if (bindings.hasProperty('__aggregate')) {
-          return aggregation(aggExpression.expression, bindings.getProperty('__aggregate'), aggExpression.separator)
+          const aggVariable = aggExpression.expression as string
+          let rows = bindings.getProperty('__aggregate')
+          if (aggExpression.distinct) {
+            rows[aggVariable] = uniqBy(rows[aggVariable], (term: terms.RDFTerm) => term.asRDF)
+          }
+          return aggregation(aggVariable, rows, aggExpression.separator)
         }
         return bindings
       }

--- a/tests/sparql/aggregates-test.js
+++ b/tests/sparql/aggregates-test.js
@@ -193,6 +193,19 @@ describe('SPARQL aggregates', () => {
 
   const data = [
     {
+      name: 'COUNT-DISTINCT',
+      query: `
+      SELECT (COUNT(DISTINCT ?p) as ?count) WHERE {
+        ?s ?p ?o
+      }
+      `,
+      keys: ['?count'],
+      nbResults: 1,
+      testFun: function (b) {
+        expect(b['?count']).to.equal(`"10"^^${XSD('integer')}`)
+      }
+    },
+    {
       name: 'SUM',
       query: `
       SELECT ?p (SUM(?x) AS ?sum) WHERE {

--- a/types/sparqljs/index.d.ts
+++ b/types/sparqljs/index.d.ts
@@ -77,13 +77,13 @@ declare module 'sparqljs' {
     }
 
     /**
-     * A custom function expression (BIND(foo:FOO(?s) as ?foo)) etc. 
+     * A custom function expression (BIND(foo:FOO(?s) as ?foo)) etc.
      */
     export interface FunctionCallExpression extends Expression {
       args: Array<string | string[] | Expression>;
       function: string;
       distinct: boolean;
-      
+
     }
     /**
      * An aggregation pexression (COUNT, SUM, AVG, etc)
@@ -92,6 +92,7 @@ declare module 'sparqljs' {
       aggregation: string;
       expression: string | Expression;
       separator?: string;
+      distinct: boolean;
     }
 
     /**


### PR DESCRIPTION
* Support for all DISTINCT aggregates based on pre-defined aggregates by passing a distinct rows object instead of the simple rows object.
* Added a test for count(distinct) only. If this one works the others should work.