### PR TITLE
Fix issues with named graphs

### DIFF
--- a/src/engine/pipeline/pipeline-engine.ts
+++ b/src/engine/pipeline/pipeline-engine.ts
@@ -361,4 +361,24 @@ export abstract class PipelineEngine {
       })
     })
   }
+
+  /**
+   * Peek values from the input pipeline stage, and use them to decide
+   * between two candidate pipeline stages to continue the pipeline.
+   * @param input - Input pipeline stage
+   * @param count - How many items to peek from the input?
+   * @param predicate - Predicate function invoked with the values
+   * @param ifCase - Callback invoked if the predicate function evaluates to True
+   * @param elseCase - Callback invoked if the predicate function evaluates to False
+   * @return A pipeline stage
+   */
+  peekIf<T, O> (input: PipelineStage<T>, count: number, predicate: (values: T[]) => boolean, ifCase: (values: T[]) => PipelineStage<O>, elseCase: (values: T[]) => PipelineStage<O>): PipelineStage<O> {
+    const peekable = this.limit(this.clone(input), count)
+    return this.mergeMap(this.collect(peekable), values => {
+      if (predicate(values)) {
+        return ifCase(values)
+      }
+      return elseCase(values)
+    })
+  }
 }

--- a/src/engine/plan-builder.ts
+++ b/src/engine/plan-builder.ts
@@ -338,14 +338,19 @@ export class PlanBuilder {
   _buildWhere (source: PipelineStage<Bindings>, groups: Algebra.PlanNode[], context: ExecutionContext): PipelineStage<Bindings> {
     groups = sortBy(groups, g => {
       switch (g.type) {
+        case 'graph':
+          if (rdf.isVariable((g as Algebra.GraphNode).name)) {
+            return 5
+          }
+          return 0
         case 'bgp':
           return 0
         case 'values':
-          return 2
-        case 'filter':
           return 3
+        case 'filter':
+          return 4
         default:
-          return 0
+          return 1
       }
     })
 

--- a/src/engine/plan-builder.ts
+++ b/src/engine/plan-builder.ts
@@ -268,7 +268,7 @@ export class PlanBuilder {
 
     // Handles WHERE clause
     let graphIterator: PipelineStage<Bindings>
-    if (query.where != null && query.where.length > 0) {
+    if (query.where.length > 0) {
       graphIterator = this._buildWhere(source, query.where, context)
     } else {
       graphIterator = engine.of(new BindingBase())
@@ -364,7 +364,7 @@ export class PlanBuilder {
     let prec = null
     for (let i = 0; i < groups.length; i++) {
       let group = groups[i]
-      if (group.type === 'bgp' && prec != null && prec.type === 'bgp') {
+      if (group.type === 'bgp' && prec !== null && prec.type === 'bgp') {
         let lastGroup = newGroups[newGroups.length - 1] as Algebra.BGPNode
         lastGroup.triples = lastGroup.triples.concat((group as Algebra.BGPNode).triples)
       } else {

--- a/tests/sparql/graph-test.js
+++ b/tests/sparql/graph-test.js
@@ -169,25 +169,35 @@ describe("GRAPH/FROM queries", () => {
       PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
       SELECT *
       WHERE {
-        BIND(<${GRAPH_B_IRI}> as ?g) .
         ?s dblp-rdf:coCreatorWith ?coCreator .
         GRAPH ?g {
           ?s2 dblp-rdf:coCreatorWith ?coCreator .
           ?s2 dblp-rdf:primaryFullPersonName ?name .
         }
       }`,
-      nbResults: 3,
+      nbResults: 7,
       testFun: function(b) {
-        expect(b).to.have.all.keys(["?s", "?s2", "?coCreator", "?name", "?g"]);
-        expect(b["?s"]).to.equal("https://dblp.org/pers/m/Minier:Thomas");
+       expect(b).to.have.all.keys(["?s", "?s2", "?coCreator", "?name", "?g"]);
+       expect(b["?s"]).to.equal("https://dblp.org/pers/m/Minier:Thomas");
+       expect(b["?g"]).to.be.oneOf([GRAPH_A_IRI, GRAPH_B_IRI]);
+       if (b['?g'] === GRAPH_A_IRI) {
+        expect(b["?s2"]).to.equal("https://dblp.org/pers/m/Minier:Thomas");
+        expect(b["?name"]).to.equal('"Thomas Minier"@en');
+        expect(b["?coCreator"]).to.be.oneOf([
+          "https://dblp.org/pers/m/Molli:Pascal",
+          "https://dblp.org/pers/m/Montoya:Gabriela",
+          "https://dblp.org/pers/s/Skaf=Molli:Hala",
+          'https://dblp.org/pers/v/Vidal:Maria=Esther'
+        ]);
+       } else {
         expect(b["?s2"]).to.equal("https://dblp.org/pers/g/Grall:Arnaud");
-        expect(b["?g"]).to.be.oneOf([GRAPH_A_IRI, GRAPH_B_IRI]);
         expect(b["?name"]).to.equal('"Arnaud Grall"');
         expect(b["?coCreator"]).to.be.oneOf([
           "https://dblp.org/pers/m/Molli:Pascal",
           "https://dblp.org/pers/m/Montoya:Gabriela",
           "https://dblp.org/pers/s/Skaf=Molli:Hala"
         ]);
+       }
       }
     }
   ];

--- a/tests/sparql/graph-test.js
+++ b/tests/sparql/graph-test.js
@@ -162,7 +162,7 @@ describe("GRAPH/FROM queries", () => {
       }
     },
     {
-      text: "should evaluate SPARQL GRAPH with the name bound in a variable",
+      text: "should evaluate a query where the graph IRI is a SPARQL variable",
       query: `
       PREFIX dblp-pers: <https://dblp.org/pers/m/>
       PREFIX dblp-rdf: <https://dblp.uni-trier.de/rdf/schema-2017-04-18#>
@@ -199,7 +199,35 @@ describe("GRAPH/FROM queries", () => {
         ]);
        }
       }
-    }
+    },
+    {
+      text: "should evaluate a SPARQL query where the graph IRI is bounded by another expression",
+      query: `
+      PREFIX dblp-pers: <https://dblp.org/pers/m/>
+      PREFIX dblp-rdf: <https://dblp.uni-trier.de/rdf/schema-2017-04-18#>
+      PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+      SELECT * WHERE {
+        ?s dblp-rdf:coCreatorWith ?coCreator .
+        BIND(<${GRAPH_B_IRI}> as ?g)
+        GRAPH ?g {
+          ?s2 dblp-rdf:coCreatorWith ?coCreator .
+          ?s2 dblp-rdf:primaryFullPersonName ?name .
+        }
+      }`,
+      nbResults: 3,
+      testFun: function(b) {
+        expect(b).to.have.all.keys(["?s", "?s2", '?g', "?coCreator", "?name"]);
+        expect(b["?s"]).to.equal("https://dblp.org/pers/m/Minier:Thomas");
+        expect(b["?s2"]).to.equal("https://dblp.org/pers/g/Grall:Arnaud");
+        expect(b['?g']).to.equals(GRAPH_B_IRI)
+        expect(b["?name"]).to.equal('"Arnaud Grall"');
+        expect(b["?coCreator"]).to.be.oneOf([
+          "https://dblp.org/pers/m/Molli:Pascal",
+          "https://dblp.org/pers/m/Montoya:Gabriela",
+          "https://dblp.org/pers/s/Skaf=Molli:Hala"
+        ]);
+      }
+    },
   ];
 
   data.forEach(d => {


### PR DESCRIPTION
This PR solves two issues:
* fix #43  where a GRAPH clause with an unbounded IRI should be evaluated over all named graphs, even if there are no FROM NAMED clause(s) in the query.
* Correct evaluation for SPARQL queries where a GRAPH clause with an unbounded IRI is bounded by another Graph pattern/SPARQL expression in the query.