### PR TITLE
Bugfixes related to the Semantic cache

### DIFF
--- a/src/engine/context/execution-context.ts
+++ b/src/engine/context/execution-context.ts
@@ -31,7 +31,7 @@ import { BGPCache } from '../cache/bgp-cache'
  * An execution context conatains control information for query execution.
  */
 export default class ExecutionContext {
-  protected _properties: Map<string, any>
+  protected _properties: Map<Symbol, any>
   protected _hints: QueryHints
   protected _defaultGraphs: string[]
   protected _namedGraphs: string[]
@@ -124,7 +124,7 @@ export default class ExecutionContext {
    * @param  key - Key associated with the property
    * @return  The value associated with the key
    */
-  getProperty (key: string): any | null {
+  getProperty (key: Symbol): any | null {
     return this._properties.get(key)
   }
 
@@ -133,7 +133,7 @@ export default class ExecutionContext {
    * @param  key - Key associated with the property
    * @return True if the context contains a property associated with the key
    */
-  hasProperty (key: string): boolean {
+  hasProperty (key: Symbol): boolean {
     return this._properties.has(key)
   }
 
@@ -142,7 +142,7 @@ export default class ExecutionContext {
    * @param key - Key of the property
    * @param value - Value of the property
    */
-  setProperty (key: string, value: any): void {
+  setProperty (key: Symbol, value: any): void {
     this._properties.set(key, value)
   }
 

--- a/src/engine/context/symbols.ts
+++ b/src/engine/context/symbols.ts
@@ -1,0 +1,34 @@
+/* file: symbols.ts
+MIT License
+
+Copyright (c) 2019-2020 Thomas Minier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the 'Software'), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+'use strict'
+
+export default {
+  /** The set of prefixes of a SPARQL query, as extracted by sparql.js */
+  'PREFIXES': Symbol('SPARQL_ENGINE_QUERY_PREFIXES'),
+  /** Identify a SPARQL query with a LIMIT clause and/or an OFFSET clause */
+  'HAS_LIMIT_OFFSET': Symbol('SPARQL_ENGINE_QUERY_HAS_LIMIT_OFFSET'),
+  /** The default buffer size used in the bound join algorithm */
+  'BOUND_JOIN_BUFFER_SIZE': Symbol('SPARQL_ENGINE_INTERNALS_BOUND_JOIN_BUFFER_SIZE')
+}

--- a/src/engine/context/symbols.ts
+++ b/src/engine/context/symbols.ts
@@ -27,7 +27,7 @@ SOFTWARE.
 export default {
   /** The set of prefixes of a SPARQL query, as extracted by sparql.js */
   'PREFIXES': Symbol('SPARQL_ENGINE_QUERY_PREFIXES'),
-  /** Identify a SPARQL query with a LIMIT clause and/or an OFFSET clause */
+  /** Identify a SPARQL query with a LIMIT modifier and/or an OFFSET modifier */
   'HAS_LIMIT_OFFSET': Symbol('SPARQL_ENGINE_QUERY_HAS_LIMIT_OFFSET'),
   /** The default buffer size used in the bound join algorithm */
   'BOUND_JOIN_BUFFER_SIZE': Symbol('SPARQL_ENGINE_INTERNALS_BOUND_JOIN_BUFFER_SIZE')

--- a/src/engine/plan-builder.ts
+++ b/src/engine/plan-builder.ts
@@ -261,6 +261,9 @@ export class PlanBuilder {
       return this._buildQueryPlan(construct, context, source)
     }
 
+    // from the begining, dectect any LIMIT/OFFSET modifiers, as they cimpact the caching strategy
+    context.setProperty(ContextSymbols.HAS_LIMIT_OFFSET, 'limit' in query || 'offset' in query)
+
     // Handles FROM clauses
     if (query.from) {
       context.defaultGraphs = query.from.default

--- a/src/engine/plan-builder.ts
+++ b/src/engine/plan-builder.ts
@@ -67,6 +67,7 @@ import {
 } from 'lodash'
 
 import ExecutionContext from './context/execution-context'
+import ContextSymbols from './context/symbols'
 import { CustomFunctions } from '../operators/expressions/sparql-expression'
 import { extractPropertyPaths } from './stages/rewritings'
 import { extendByBindings, deepApplyBindings, rdf } from '../utils'
@@ -233,7 +234,7 @@ export class PlanBuilder {
       // build pipeline starting iterator
       source = engine.of(new BindingBase())
     }
-    context.setProperty('prefixes', query.prefixes)
+    context.setProperty(ContextSymbols.PREFIXES, query.prefixes)
 
     let aggregates: any[] = []
 

--- a/src/engine/stages/graph-stage-builder.ts
+++ b/src/engine/stages/graph-stage-builder.ts
@@ -31,6 +31,7 @@ import { rdf } from '../../utils'
 import { Algebra } from 'sparqljs'
 import { Bindings } from '../../rdf/bindings'
 import ExecutionContext from '../context/execution-context'
+import ContextSymbols from '../context/symbols'
 
 /**
  * A GraphStageBuilder evaluates GRAPH clauses in a SPARQL query.
@@ -50,7 +51,7 @@ export default class GraphStageBuilder extends StageBuilder {
       subquery = node.patterns[0] as Algebra.RootNode
     } else {
       subquery = {
-        prefixes: context.getProperty('prefixes'),
+        prefixes: context.getProperty(ContextSymbols.PREFIXES),
         queryType: 'SELECT',
         variables: ['*'],
         type: 'query',

--- a/src/engine/stages/service-stage-builder.ts
+++ b/src/engine/stages/service-stage-builder.ts
@@ -30,6 +30,7 @@ import { Pipeline } from '../pipeline/pipeline'
 import { PipelineStage } from '../pipeline/pipeline-engine'
 import { Bindings } from '../../rdf/bindings'
 import ExecutionContext from '../context/execution-context'
+import ContextSymbols from '../context/symbols'
 
 /**
  * A ServiceStageBuilder is responsible for evaluation a SERVICE clause in a SPARQL query.
@@ -50,7 +51,7 @@ export default class ServiceStageBuilder extends StageBuilder {
       subquery = node.patterns[0] as Algebra.RootNode
     } else {
       subquery = {
-        prefixes: context.getProperty('prefixes'),
+        prefixes: context.getProperty(ContextSymbols.PREFIXES),
         queryType: 'SELECT',
         variables: ['*'],
         type: 'query',

--- a/src/engine/stages/update-stage-builder.ts
+++ b/src/engine/stages/update-stage-builder.ts
@@ -38,6 +38,7 @@ import Graph from '../../rdf/graph'
 import { Algebra } from 'sparqljs'
 import { Bindings, BindingBase } from '../../rdf/bindings'
 import ExecutionContext from '../context/execution-context'
+import ContextSymbols from '../context/symbols'
 
 /**
  * An UpdateStageBuilder evaluates SPARQL UPDATE queries.
@@ -109,7 +110,7 @@ export default class UpdateStageBuilder extends StageBuilder {
       graph = ('graph' in update) ? this._dataset.getNamedGraph(update.graph!) : null
       // evaluate the WHERE clause as a classic SELECT query
       const node: Algebra.RootNode = {
-        prefixes: context.getProperty('prefixes'),
+        prefixes: context.getProperty(ContextSymbols.PREFIXES),
         type: 'query',
         where: update.where!,
         queryType: 'SELECT',

--- a/src/operators/join/bound-join.ts
+++ b/src/operators/join/bound-join.ts
@@ -31,6 +31,7 @@ import { PipelineStage, StreamPipelineInput } from '../../engine/pipeline/pipeli
 import { rdf, evaluation } from '../../utils'
 import BGPStageBuilder from '../../engine/stages/bgp-stage-builder'
 import ExecutionContext from '../../engine/context/execution-context'
+import ContextSymbols from '../../engine/context/symbols'
 import Graph from '../../rdf/graph'
 import rewritingOp from './rewriting-op'
 
@@ -81,8 +82,8 @@ export default function boundJoin (source: PipelineStage<Bindings>, bgp: Algebra
     // Check if a custom bucket size for the bound join buffer has been set by in the context
     // Otherwise, use the default one
     let bufferSize = BOUND_JOIN_BUFFER_SIZE
-    if (context.hasProperty('BOUND_JOIN_BUFFER_SIZE')) {
-      bufferSize = context.getProperty('BOUND_JOIN_BUFFER_SIZE')
+    if (context.hasProperty(ContextSymbols.BOUND_JOIN_BUFFER_SIZE)) {
+      bufferSize = context.getProperty(ContextSymbols.BOUND_JOIN_BUFFER_SIZE)
     }
 
     // Utility function used to close the processing

--- a/src/operators/join/rewriting-op.ts
+++ b/src/operators/join/rewriting-op.ts
@@ -99,11 +99,11 @@ export default function rewritingOp (graph: Graph, bgpBucket: Algebra.TripleObje
     // partition the BGPs that can be evaluated using the cache from the others
     const stages: PipelineStage<Bindings>[] = []
     const others: Algebra.TripleObject[][] = []
-    bgpBucket.forEach(bgp => {
-      if (context.cache!.has(bgp)) {
-        stages.push(evaluation.cacheEvalBGP(bgp, graph, context.cache!, builder, context))
+    bgpBucket.forEach(patterns => {
+      if (context.cache!.has({ patterns, graphIRI: graph.iri })) {
+        stages.push(evaluation.cacheEvalBGP(patterns, graph, context.cache!, builder, context))
       } else {
-        others.push(bgp)
+        others.push(patterns)
       }
     })
     // merge all sources from the cache first, and then the evaluation of bgp that are not in the cache

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -38,6 +38,7 @@ import * as DataFactory from '@rdfjs/data-model'
 import * as uuid from 'uuid/v4'
 import BGPStageBuilder from './engine/stages/bgp-stage-builder'
 import ExecutionContext from './engine/context/execution-context'
+import ContextSymbols from './engine/context/symbols'
 import Graph from './rdf/graph'
 
 /**
@@ -558,6 +559,11 @@ export namespace evaluation {
     const [subsetBGP, missingBGP] = cache.findSubset(bgp)
     // case 1: no subset of the BGP are in cache => classic evaluation (most frequent)
     if (subsetBGP.length === 0) {
+      // we cannot cache the BGP if the query has a LIMIT and/or OFFSET modiifier
+      // otherwise we will cache incomplete results. So, we just evaluate the BGP
+      if (context.hasProperty(ContextSymbols.HAS_LIMIT_OFFSET) && context.getProperty(ContextSymbols.HAS_LIMIT_OFFSET)) {
+        return graph.evalBGP(bgp, context)
+      }
       // generate an unique writer ID
       const writerID = uuid()
       // evaluate the BGP while saving all solutions into the cache

--- a/tests/cache/bgp-cache-test.js
+++ b/tests/cache/bgp-cache-test.js
@@ -28,6 +28,16 @@ const expect = require('chai').expect
 const { LRUBGPCache } = require('../../dist/engine/cache/bgp-cache')
 const { BindingBase } = require('../../dist/api.js')
 
+/**
+ * Format a BGP to the format expected by a BGPCache: an object
+ * with fields 'patterns' and 'graphIRI'
+ * @param {*} patterns - Set of triple patterns
+ * @param {*} graphIRI - Graph's IRI
+ */
+function formatBGP(patterns, graphIRI) {
+  return { patterns, graphIRI }
+}
+
 describe('LRUBGPCache', () => {
   let cache = null
   beforeEach(() => {
@@ -37,7 +47,8 @@ describe('LRUBGPCache', () => {
   describe('#update/commit', () => {
     it('should supports insertion of items over time', done => {
       const writerID = 1
-      const bgp = [ { subject: '?s', predicate: 'rdf:type', object: '?type' } ]
+      const patterns = [ { subject: '?s', predicate: 'rdf:type', object: '?type' } ]
+      const bgp = formatBGP(patterns, 'http://example.org#graphA')
       const bindings = [
         BindingBase.fromObject({ '?s': ':s1', '?type': ':c1' }),
         BindingBase.fromObject({ '?s': ':s2', '?type': ':c2' })
@@ -55,54 +66,61 @@ describe('LRUBGPCache', () => {
   describe('#findSubset', () => {
     it('should find a subset for a Basic Graph Pattern which is partially in the cache', () => {
       // populate cache
-      const subsetBGP = [ { subject: '?s', predicate: 'rdf:type', object: '?type'} ]
+      const subsetPatterns = [ { subject: '?s', predicate: 'rdf:type', object: '?type'} ]
+      const subsetBGP = formatBGP(subsetPatterns, 'http://example.org#graphA')
       cache.update(subsetBGP, BindingBase.fromObject({ '?s': ':s1' }), 1)
       cache.commit(subsetBGP, 1)
       // search for subset
-      const bgp = [ 
+      const patterns = [ 
         { subject: '?s', predicate: 'rdf:type', object: '?type'},
         { subject: '?s', predicate: 'foaf:name', object: '?name'}
       ]
+      const bgp = formatBGP(patterns, 'http://example.org#graphA')
       const [computedSubset, computedMissing] = cache.findSubset(bgp)
-      expect(computedSubset).to.deep.equals(subsetBGP)
-      expect(computedMissing).to.deep.equals([ bgp[1] ])
+      expect(computedSubset).to.deep.equals(subsetPatterns)
+      expect(computedMissing).to.deep.equals([ patterns[1] ])
     })
 
     it('should find an empty subset for a Basic Graph Pattern with no valid subset in the cache', () => {
       // populate cache
-      const subsetBGP = [ { subject: '?s', predicate: 'rdf:type', object: '?type'} ]
+      const subsetPatterns = [ { subject: '?s', predicate: 'rdf:type', object: '?type'} ]
+      const subsetBGP = formatBGP(subsetPatterns, 'http://example.org#graphA')
       cache.update(subsetBGP, BindingBase.fromObject({ '?s': ':s1' }), 1)
       cache.commit(subsetBGP, 1)
       // search for subset
-      const bgp = [ 
+      const patterns = [ 
         { subject: '?s', predicate: 'foaf:knows', object: '?type' },
         { subject: '?s', predicate: 'foaf:name', object: '?name' }
       ]
+      const bgp = formatBGP(patterns, 'http://example.org#graphA')
       const [computedSubset, computedMissing] = cache.findSubset(bgp)
       expect(computedSubset.length).to.equals(0)
-      expect(computedMissing).to.deep.equals(bgp)
+      expect(computedMissing).to.deep.equals(patterns)
     })
 
     it('should find the largest subset from the cache entry', () => {
       // populate cache
-      const subsetBGP_a = [ { subject: '?s', predicate: 'rdf:type', object: '?type'} ]
-      const subsetBGP_b = [ 
+      const subsetPatterns_a = [ { subject: '?s', predicate: 'rdf:type', object: '?type'} ]
+      const subsetPatterns_b = [ 
         { subject: '?s', predicate: 'rdf:type', object: '?type' },
         { subject: '?s', predicate: 'foaf:name', object: '?name' }
       ]
+      const subsetBGP_a = formatBGP(subsetPatterns_a, 'http://example.org#graphA')
+      const subsetBGP_b = formatBGP(subsetPatterns_b, 'http://example.org#graphA')
       cache.update(subsetBGP_a, BindingBase.fromObject({ '?s': ':s1' }), 1)
       cache.commit(subsetBGP_a, 1)
       cache.update(subsetBGP_b, BindingBase.fromObject({ '?s': ':s2' }), 1)
       cache.commit(subsetBGP_b, 1)
       // search for subset
-      const bgp = [ 
+      const patterns = [ 
         { subject: '?s', predicate: 'rdf:type', object: '?type' },
         { subject: '?s', predicate: 'foaf:knows', object: '?type' },
         { subject: '?s', predicate: 'foaf:name', object: '?name' }
       ]
+      const bgp = formatBGP(patterns, 'http://example.org#graphA')
       const [computedSubset, computedMissing] = cache.findSubset(bgp)
-      expect(computedSubset).to.deep.equals(subsetBGP_b)
-      expect(computedMissing).to.deep.equals([ bgp[1] ])
+      expect(computedSubset).to.deep.equals(subsetPatterns_b)
+      expect(computedMissing).to.deep.equals([ patterns[1] ])
     })
   })
 })

--- a/tests/sparql/semantic-cache-test.js
+++ b/tests/sparql/semantic-cache-test.js
@@ -50,7 +50,10 @@ describe('Semantic caching for SPARQL queries', () => {
       // we have all results in double
       expect(results.length).to.equal(34)
       // check for cache hits
-      const bgp = [ { subject: '?s', predicate: '?p', object: '?o' } ]
+      const bgp = {
+        patterns: [ { subject: '?s', predicate: '?p', object: '?o' } ],
+        graphIRI: engine.defaultGraphIRI()
+      }
       const cache = engine._builder._currentCache
       expect(cache.count()).to.equal(1)
       expect(cache.has(bgp)).to.equal(true)
@@ -78,7 +81,10 @@ describe('Semantic caching for SPARQL queries', () => {
       // we have all results
       expect(results.length).to.equal(10)
       // assert that the cache is empty for this BGP
-      const bgp = [ { subject: '?s', predicate: '?p', object: '?o' } ]
+      const bgp = {
+        patterns: [ { subject: '?s', predicate: '?p', object: '?o' } ],
+        graphIRI: engine.defaultGraphIRI()
+      }
       const cache = engine._builder._currentCache
       expect(cache.count()).to.equal(0)
       expect(cache.has(bgp)).to.equal(false)
@@ -103,7 +109,10 @@ describe('Semantic caching for SPARQL queries', () => {
       // we have all results in double - 10 (due to then offfset)
       expect(results.length).to.equal(24)
       // assert that the cache is empty for this BGP
-      const bgp = [ { subject: '?s', predicate: '?p', object: '?o' } ]
+      const bgp = {
+        patterns: [ { subject: '?s', predicate: '?p', object: '?o' } ],
+        graphIRI: engine.defaultGraphIRI()
+      }
       const cache = engine._builder._currentCache
       expect(cache.count()).to.equal(0)
       expect(cache.has(bgp)).to.equal(false)

--- a/tests/sparql/semantic-cache-test.js
+++ b/tests/sparql/semantic-cache-test.js
@@ -1,4 +1,4 @@
-/* file : union-test.js
+/* file : semantic-cache-test.js
 MIT License
 
 Copyright (c) 2018-2020 Thomas Minier
@@ -27,7 +27,7 @@ SOFTWARE.
 const expect = require('chai').expect
 const { getGraph, TestEngine } = require('../utils.js')
 
-describe('Basic Graph Pattern cache', () => {
+describe('Semantic caching for SPARQL queries', () => {
   let engine = null
   before(() => {
     const g = getGraph('./tests/data/dblp.nt')
@@ -59,6 +59,56 @@ describe('Basic Graph Pattern cache', () => {
         expect(content.length).to.equals(17)
         done()
       }).catch(done)
+    })
+  })
+
+  it('should not cache BGPs when the query has a LIMIT modifier', done => {
+    const query = `
+    SELECT ?s ?p ?o WHERE {
+      { ?s ?p ?o } UNION { ?s ?p ?o }
+    } LIMIT 10`
+    engine._builder.useCache()
+    const results = []
+    const iterator = engine.execute(query)
+    iterator.subscribe(b => {
+      b = b.toObject()
+      expect(b).to.have.keys('?s', '?p', '?o')
+      results.push(b)
+    }, done, () => {
+      // we have all results
+      expect(results.length).to.equal(10)
+      // assert that the cache is empty for this BGP
+      const bgp = [ { subject: '?s', predicate: '?p', object: '?o' } ]
+      const cache = engine._builder._currentCache
+      expect(cache.count()).to.equal(0)
+      expect(cache.has(bgp)).to.equal(false)
+      expect(cache.get(bgp)).to.be.null
+      done()
+    })
+  })
+
+  it('should not cache BGPs when the query has an OFFSET modifier', done => {
+    const query = `
+    SELECT ?s ?p ?o WHERE {
+      { ?s ?p ?o } UNION { ?s ?p ?o }
+    } OFFSET 10`
+    engine._builder.useCache()
+    const results = []
+    const iterator = engine.execute(query)
+    iterator.subscribe(b => {
+      b = b.toObject()
+      expect(b).to.have.keys('?s', '?p', '?o')
+      results.push(b)
+    }, done, () => {
+      // we have all results in double - 10 (due to then offfset)
+      expect(results.length).to.equal(24)
+      // assert that the cache is empty for this BGP
+      const bgp = [ { subject: '?s', predicate: '?p', object: '?o' } ]
+      const cache = engine._builder._currentCache
+      expect(cache.count()).to.equal(0)
+      expect(cache.has(bgp)).to.equal(false)
+      expect(cache.get(bgp)).to.be.null
+      done()
     })
   })
 })

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -128,8 +128,13 @@ class UnionN3Graph extends N3Graph {
 class TestEngine {
   constructor(graph, defaultGraphIRI = null, customOperations = {}) {
     this._graph = graph
-    this._dataset = new HashMapDataset(defaultGraphIRI, this._graph)
+    this._defaultGraphIRI = (defaultGraphIRI === null) ? this._graph.iri : defaultGraphIRI
+    this._dataset = new HashMapDataset(this._defaultGraphIRI, this._graph)
     this._builder = new PlanBuilder(this._dataset, {}, customOperations)
+  }
+
+  defaultGraphIRI() {
+    return this._defaultGraphIRI
   }
 
   addNamedGraph(iri, db) {


### PR DESCRIPTION
This PR fixes two bugs related to the semantic cache.
* Results for SPARQL queries with LIMIT and/or OFFSET modifiers were cached, despite their incompleteness. The semantic cache is now automatically disabled for such type of queries, regardless of the user configuration.
* Two identic BGPs but evaluated on two distinct graphs were identified as the same BGP for the semantic cache, which can lead to false results for queries with GRAPH/SERVICE clauses. The LRUBGCache now includes the Graph IRI in the cache keys.