### PR TITLE
Bugfix for the bound join algorithm

### DIFF
--- a/src/engine/context/symbols.ts
+++ b/src/engine/context/symbols.ts
@@ -30,5 +30,7 @@ export default {
   /** Identify a SPARQL query with a LIMIT modifier and/or an OFFSET modifier */
   'HAS_LIMIT_OFFSET': Symbol('SPARQL_ENGINE_QUERY_HAS_LIMIT_OFFSET'),
   /** The default buffer size used in the bound join algorithm */
-  'BOUND_JOIN_BUFFER_SIZE': Symbol('SPARQL_ENGINE_INTERNALS_BOUND_JOIN_BUFFER_SIZE')
+  'BOUND_JOIN_BUFFER_SIZE': Symbol('SPARQL_ENGINE_INTERNALS_BOUND_JOIN_BUFFER_SIZE'),
+  /** Forces all joins to be done using the Index Join algorithm */
+  'FORCE_INDEX_JOIN': Symbol('SPARQL_ENGINE_FORCE_INDEX_JOIN')
 }

--- a/src/engine/pipeline/pipeline-engine.ts
+++ b/src/engine/pipeline/pipeline-engine.ts
@@ -174,6 +174,15 @@ export abstract class PipelineEngine {
   }
 
   /**
+   * Flatten the output of pipeline stage that emits array of values into a pipeline that emits single values.
+   * @param  input  - Input PipelineStage
+   * @return Output PipelineStage
+   */
+  flatten<T> (input: PipelineStage<T[]>): PipelineStage<T> {
+    return this.flatMap(input, v => v)
+  }
+
+  /**
    * Filter items emitted by the source PipelineStage by only emitting those that satisfy a specified predicate.
    * @param  input     - Input PipelineStage
    * @param  predicate - Predicate function

--- a/src/engine/pipeline/pipeline-engine.ts
+++ b/src/engine/pipeline/pipeline-engine.ts
@@ -174,7 +174,7 @@ export abstract class PipelineEngine {
   }
 
   /**
-   * Flatten the output of pipeline stage that emits array of values into a pipeline that emits single values.
+   * Flatten the output of a pipeline stage that emits array of values into single values.
    * @param  input  - Input PipelineStage
    * @return Output PipelineStage
    */

--- a/src/engine/stages/bgp-stage-builder.ts
+++ b/src/engine/stages/bgp-stage-builder.ts
@@ -35,6 +35,7 @@ import { GRAPH_CAPABILITY } from '../../rdf/graph_capability'
 import { parseHints } from '../context/query-hints'
 import { fts } from './rewritings'
 import ExecutionContext from '../context/execution-context'
+import ContextSymbols from '../context/symbols'
 import { rdf, evaluation } from '../../utils'
 import { isNaN, isNull, isInteger } from 'lodash'
 
@@ -183,7 +184,7 @@ export default class BGPStageBuilder extends StageBuilder {
    * @return A {@link PipelineStage} used to evaluate a Basic Graph pattern
    */
   _buildIterator (source: PipelineStage<Bindings>, graph: Graph, patterns: Algebra.TripleObject[], context: ExecutionContext): PipelineStage<Bindings> {
-    if (graph._isCapable(GRAPH_CAPABILITY.UNION)) {
+    if (graph._isCapable(GRAPH_CAPABILITY.UNION) && !context.hasProperty(ContextSymbols.FORCE_INDEX_JOIN)) {
       return boundJoin(source, patterns, graph, this, context)
     }
     return bgpEvaluation(source, patterns, graph, this, context)

--- a/src/operators/join/bound-join.ts
+++ b/src/operators/join/bound-join.ts
@@ -27,7 +27,7 @@ SOFTWARE.
 import { Algebra } from 'sparqljs'
 import { Bindings } from '../../rdf/bindings'
 import { Pipeline } from '../../engine/pipeline/pipeline'
-import { PipelineStage, StreamPipelineInput } from '../../engine/pipeline/pipeline-engine'
+import { PipelineStage } from '../../engine/pipeline/pipeline-engine'
 import { rdf, evaluation } from '../../utils'
 import BGPStageBuilder from '../../engine/stages/bgp-stage-builder'
 import ExecutionContext from '../../engine/context/execution-context'

--- a/src/operators/join/bound-join.ts
+++ b/src/operators/join/bound-join.ts
@@ -130,7 +130,7 @@ export default function boundJoin (source: PipelineStage<Bindings>, bgp: Algebra
         newContext.setProperty(ContextSymbols.FORCE_INDEX_JOIN, true)
         regularStage = Pipeline.getInstance().merge(...regularBucket.map(bgp => {
           const clonedBucket = bucket.map(b => b.clone())
-          const source = Pipeline.getInstance().flatMap(Pipeline.getInstance().of(clonedBucket), b => b)
+          const source = Pipeline.getInstance().flatten(Pipeline.getInstance().of(clonedBucket))
           return builder._buildIterator(source, graph, bgp, newContext)
         }))
       }

--- a/src/operators/join/bound-join.ts
+++ b/src/operators/join/bound-join.ts
@@ -118,6 +118,7 @@ export default function boundJoin (source: PipelineStage<Bindings>, bgp: Algebra
           regularBucket.push(regularBGP)
         }
       })
+
       let bucketStage: PipelineStage<Bindings> = Pipeline.getInstance().empty()
       let regularStage: PipelineStage<Bindings> = Pipeline.getInstance().empty()
       // Evaluates the bucket using the graph, then rewrite it to produce join results
@@ -126,8 +127,10 @@ export default function boundJoin (source: PipelineStage<Bindings>, bgp: Algebra
       }
       // Invoke the BGPStageBuilder to evaluates the BGPs that cannot be evaluated by a bound join
       if (regularBucket.length > 0) {
+        // create a new context where we force the execution of joins using Index Joins
         const newContext = context.clone()
         newContext.setProperty(ContextSymbols.FORCE_INDEX_JOIN, true)
+        // Invoke the BGPStageBuilder to evaluate the bucket
         regularStage = Pipeline.getInstance().merge(...regularBucket.map(bgp => {
           const clonedBucket = bucket.map(b => b.clone())
           const source = Pipeline.getInstance().flatten(Pipeline.getInstance().of(clonedBucket))

--- a/src/operators/join/rewriting-op.ts
+++ b/src/operators/join/rewriting-op.ts
@@ -42,7 +42,7 @@ function findKey (variables: IterableIterator<string>, maxValue: number = 15): n
   let key = -1
   for (let v of variables) {
     for (let i = 0; i < maxValue; i++) {
-      if (v.endsWith('_' + i)) {
+      if (v.endsWith(`_${i}`)) {
         return i
       }
     }
@@ -57,8 +57,9 @@ function findKey (variables: IterableIterator<string>, maxValue: number = 15): n
 function revertBinding (key: number, input: Bindings, variables: IterableIterator<string>): Bindings {
   const newBinding = input.empty()
   for (let vName of variables) {
-    if (vName.endsWith('_' + key)) {
-      const index = vName.indexOf('_' + key)
+    let suffix = `_${key}`
+    if (vName.endsWith(suffix)) {
+      const index = vName.indexOf(suffix)
       newBinding.set(vName.substring(0, index), input.get(vName)!)
     } else {
       newBinding.set(vName, input.get(vName)!)

--- a/src/operators/join/rewriting-op.ts
+++ b/src/operators/join/rewriting-op.ts
@@ -111,7 +111,5 @@ export default function rewritingOp (graph: Graph, bgpBucket: Algebra.TripleObje
   } else {
     source = graph.evalUnion(bgpBucket, context)
   }
-  return Pipeline.getInstance().map(source, bindings => {
-    return rewriteSolutions(bindings, rewritingTable)
-  })
+  return Pipeline.getInstance().map(source, bindings => rewriteSolutions(bindings, rewritingTable))
 }

--- a/tests/pipeline/fixtures.js
+++ b/tests/pipeline/fixtures.js
@@ -312,6 +312,25 @@ function testPipelineEngine (pipeline) {
     })
   })
 
+  // flatten method
+  describe('#flattend', () => {
+    it('shoudl flatten the output of a PipelineStage that emits array of values', done => {
+      const out = pipeline.flatten(pipeline.of([1, 2], [3, 4], [5, 6]))
+      const expected = [1, 2, 3, 4, 5, 6]
+      let cpt = 0
+      out.subscribe(x => {
+        expect(x).to.be.oneOf(expected)
+        // pull out element
+        expected.splice(expected.indexOf(x), 1)
+        cpt++
+      }, done, () => {
+        expect(cpt).to.equal(6)
+        expect(expected.length).to.equal(0)
+        done()
+      })
+    })
+  })
+
   // reduce method
   describe('#reduce', () => {
     it('should reduce elements emitted by a PipelineStage', done => {

--- a/tests/sparql/service-bound-join-test.js
+++ b/tests/sparql/service-bound-join-test.js
@@ -72,6 +72,24 @@ describe('SERVICE queries (using bound joins)', () => {
           'https://dblp.org/rec/conf/esws/MinierMSM17a'
         ])
       }
+    },
+    {
+      text: 'should evaluate SERVICE queries that requires containement queries',
+      query: `
+      PREFIX dblp-pers: <https://dblp.org/pers/m/>
+      PREFIX dblp-rdf: <https://dblp.uni-trier.de/rdf/schema-2017-04-18#>
+      PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+      SELECT * WHERE {
+        ?s rdf:type dblp-rdf:Person .
+        SERVICE <${GRAPH_A_IRI}> {
+          ?s dblp-rdf:primaryFullPersonName "Thomas Minier"@en .
+        }
+      }`,
+      nbResults: 1,
+      testFun: function (b) {
+        expect(b).to.have.all.keys(['?s'])
+        expect(b['?s']).to.equal('https://dblp.org/pers/m/Minier:Thomas')
+      }
     }
   ]
 

--- a/tests/sparql/service-bound-join-test.js
+++ b/tests/sparql/service-bound-join-test.js
@@ -74,7 +74,7 @@ describe('SERVICE queries (using bound joins)', () => {
       }
     },
     {
-      text: 'should evaluate SERVICE queries that requires containement queries',
+      text: 'should evaluate simple SERVICE queries that requires containement queries',
       query: `
       PREFIX dblp-pers: <https://dblp.org/pers/m/>
       PREFIX dblp-rdf: <https://dblp.uni-trier.de/rdf/schema-2017-04-18#>
@@ -90,7 +90,33 @@ describe('SERVICE queries (using bound joins)', () => {
         expect(b).to.have.all.keys(['?s'])
         expect(b['?s']).to.equal('https://dblp.org/pers/m/Minier:Thomas')
       }
-    }
+    },
+    {
+      text: 'should evaluate complex SERVICE queries that requires containement queries',
+      query: `
+      PREFIX dblp-pers: <https://dblp.org/pers/m/>
+      PREFIX dblp-rdf: <https://dblp.uni-trier.de/rdf/schema-2017-04-18#>
+      PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+      SELECT ?s ?article WHERE {
+        ?s rdf:type dblp-rdf:Person .
+        ?s dblp-rdf:authorOf ?article .
+        SERVICE <${GRAPH_A_IRI}> {
+          ?s dblp-rdf:primaryFullPersonName "Thomas Minier"@en .
+        }
+      }`,
+      nbResults: 5,
+      testFun: function (b) {
+        expect(b).to.have.all.keys(['?s', '?article'])
+        expect(b['?s']).to.equal('https://dblp.org/pers/m/Minier:Thomas')
+        expect(b['?article']).to.be.oneOf([
+          'https://dblp.org/rec/conf/esws/MinierSMV18a',
+          'https://dblp.org/rec/conf/esws/MinierSMV18',
+          'https://dblp.org/rec/journals/corr/abs-1806-00227',
+          'https://dblp.org/rec/conf/esws/MinierMSM17',
+          'https://dblp.org/rec/conf/esws/MinierMSM17a'
+        ])
+      }
+    },
   ]
 
   data.forEach(d => {


### PR DESCRIPTION
This PR fixes a bug with the Bound Join operator. Basically, this join algorithm cannot work when joining with a BGP which no longer contains variables after we bound it. As the algorithm relies on variables renaming to track which set of bindings connect to which parts of the UNION, the bound join no longer works in this case.

To solve this, I implemented the following strategy: if some subset of the bucket of bindings can be evaluated under a bound join, then we process them with the bound join algorithm. The remaining set of bindings is processed using the regular Index Join algorithm.

This PR also adds two new unit tests that highlight this situation.