### PR TITLE
Add support for CREATE and DROP queries

### DIFF
--- a/src/engine/stages/update-stage-builder.ts
+++ b/src/engine/stages/update-stage-builder.ts
@@ -73,12 +73,25 @@ export default class UpdateStageBuilder extends StageBuilder {
             const iri = createNode.graph.name
             if (this._dataset.hasNamedGraph(iri)) {
               if (!createNode.silent) {
-                return new ErrorConsumable(`Cannot create the Graph with iri ${iri} as it already exists`)
+                return new ErrorConsumable(`Cannot create the Graph with iri ${iri} as it already exists in the RDF dataset`)
               }
               return new NoopConsumer()
             }
             return new ActionConsumer(() => {
               this._dataset.addNamedGraph(iri, this._dataset.createGraph(iri))
+            })
+          }
+          case 'drop': {
+            const createNode = update as Algebra.UpdateCreateDropNode
+            const iri = createNode.graph.name
+            if (!this._dataset.hasNamedGraph(iri)) {
+              if (!createNode.silent) {
+                return new ErrorConsumable(`Cannot drop the Graph with iri ${iri} as it doesn't exists in the RDF dataset`)
+              }
+              return new NoopConsumer()
+            }
+            return new ActionConsumer(() => {
+              this._dataset.deleteNamedGraph(iri)
             })
           }
           case 'clear':

--- a/src/engine/stages/update-stage-builder.ts
+++ b/src/engine/stages/update-stage-builder.ts
@@ -83,7 +83,6 @@ export default class UpdateStageBuilder extends StageBuilder {
           }
           case 'drop': {
             const dropNode = update as Algebra.UpdateCreateDropNode
-            console.log(dropNode);
             // handle DROP DEFAULT queries
             if ('default' in dropNode.graph && dropNode.graph.default) {
               return new ActionConsumer(() => {
@@ -96,6 +95,11 @@ export default class UpdateStageBuilder extends StageBuilder {
               })
             }
             // handle DROP ALL queries
+            if ('all' in dropNode.graph && dropNode.graph.all) {
+              return new ActionConsumer(() => {
+                this._dataset.iris.forEach(iri => this._dataset.deleteNamedGraph(iri))
+              })
+            }
             // handle DROP GRAPH queries
             const iri = dropNode.graph.name
             if (!this._dataset.hasNamedGraph(iri)) {

--- a/src/operators/update/action-consumer.ts
+++ b/src/operators/update/action-consumer.ts
@@ -1,0 +1,40 @@
+/* file: action-consumer.ts
+MIT License
+
+Copyright (c) 2019-2020 Thomas Minier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the 'Software'), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+import { Consumable } from './consumer'
+
+/**
+ * A consumer that executes a simple action
+ * @author Thomas Minier
+ */
+export default class ActionConsumer implements Consumable {
+  constructor (private _action: () => void) {}
+
+  execute (): Promise<void> {
+    return new Promise(resolve => {
+      this._action()
+      resolve()
+    })
+  }
+}

--- a/src/operators/update/nop-consumer.ts
+++ b/src/operators/update/nop-consumer.ts
@@ -1,0 +1,35 @@
+/* file: nop-consumer.ts
+MIT License
+
+Copyright (c) 2019-2020 Thomas Minier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the 'Software'), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+import { Consumable } from './consumer'
+
+/**
+ * A Consumer that does nothing
+ * @author Thomas Minier
+ */
+export default class NoopConsumer implements Consumable {
+  execute (): Promise<void> {
+    return Promise.resolve()
+  }
+}

--- a/src/rdf/dataset.ts
+++ b/src/rdf/dataset.ts
@@ -70,6 +70,12 @@ export default abstract class Dataset {
   abstract getNamedGraph (iri: string): Graph
 
   /**
+   * Delete a Named Graph using its IRI
+   * @param  iri - IRI of the Named Graph to delete
+   */
+  abstract deleteNamedGraph (iri: string): void
+
+  /**
    * Return True if the Dataset contains a Named graph with the provided IRI
    * @param  iri - IRI of the Named Graph
    * @return True if the Dataset contains a Named graph with the provided IRI

--- a/src/rdf/hashmap-dataset.ts
+++ b/src/rdf/hashmap-dataset.ts
@@ -76,4 +76,12 @@ export default class HashMapDataset extends Dataset {
   hasNamedGraph (iri: string): boolean {
     return this._namedGraphs.has(iri)
   }
+
+  deleteNamedGraph (iri: string): void {
+    if (this._namedGraphs.has(iri)) {
+      this._namedGraphs.delete(iri)
+    } else {
+      throw new Error(`Cannot delete unknown graph with iri ${iri}`)
+    }
+  }
 }

--- a/tests/update/create-test.js
+++ b/tests/update/create-test.js
@@ -1,0 +1,62 @@
+/* file : create-test.js
+MIT License
+
+Copyright (c) 2018-2020 Thomas Minier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+'use strict'
+
+const expect = require('chai').expect
+const { getGraph, TestEngine, N3Graph } = require('../utils.js')
+
+const GRAPH_A_IRI = 'http://example.org#some-graph-a'
+const GRAPH_B_IRI = 'http://example.org#some-graph-b'
+
+describe('SPARQL UPDATE: CREATE queries', () => {
+  let engine = null
+  beforeEach(() => {
+    const gA = getGraph('./tests/data/dblp.nt')
+    engine = new TestEngine(gA, GRAPH_A_IRI)
+    engine._dataset.setGraphFactory(iri => new N3Graph())
+  })
+
+  const data = [
+    {
+      name: 'CREATE GRAPH',
+      query: `CREATE GRAPH <${GRAPH_B_IRI}>`,
+      testFun: () => {
+        expect(engine.hasNamedGraph(GRAPH_B_IRI)).to.equal(true)
+      }
+    }
+  ]
+
+  data.forEach(d => {
+    it(`should evaluate "${d.name}" queries`, done => {
+      engine.execute(d.query)
+        .execute()
+        .then(() => {
+          d.testFun()
+          done()
+        })
+        .catch(done)
+    })
+  })
+})

--- a/tests/update/drop-test.js
+++ b/tests/update/drop-test.js
@@ -54,6 +54,13 @@ describe('SPARQL UPDATE: DROP queries', () => {
         expect(engine.hasNamedGraph(GRAPH_A_IRI)).to.equal(false)
         expect(engine.defaultGraphIRI()).to.equal(GRAPH_B_IRI)
       }
+    },
+    {
+      name: 'DROP ALL',
+      query: `DROP ALL`,
+      testFun: () => {
+        expect(engine._dataset.iris).to.equal(0)
+      }
     }
   ]
 

--- a/tests/update/drop-test.js
+++ b/tests/update/drop-test.js
@@ -1,0 +1,63 @@
+/* file : create-test.js
+MIT License
+
+Copyright (c) 2018-2020 Thomas Minier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+'use strict'
+
+const expect = require('chai').expect
+const { getGraph, TestEngine } = require('../utils.js')
+
+const GRAPH_A_IRI = 'http://example.org#some-graph-a'
+const GRAPH_B_IRI = 'http://example.org#some-graph-b'
+
+describe('SPARQL UPDATE: DROP queries', () => {
+  let engine = null
+  beforeEach(() => {
+    const gA = getGraph('./tests/data/dblp.nt')
+    const gB = getGraph('./tests/data/dblp.nt')
+    engine = new TestEngine(gA, GRAPH_A_IRI)
+    engine.addNamedGraph(GRAPH_B_IRI, gB)
+  })
+
+  const data = [
+    {
+      name: 'DROP GRAPH',
+      query: `DROP GRAPH <${GRAPH_B_IRI}>`,
+      testFun: () => {
+        expect(engine.hasNamedGraph(GRAPH_B_IRI)).to.equal(false)
+      }
+    }
+  ]
+
+  data.forEach(d => {
+    it(`should evaluate "${d.name}" queries`, done => {
+      engine.execute(d.query)
+        .execute()
+        .then(() => {
+          d.testFun()
+          done()
+        })
+        .catch(done)
+    })
+  })
+})

--- a/tests/update/drop-test.js
+++ b/tests/update/drop-test.js
@@ -46,6 +46,14 @@ describe('SPARQL UPDATE: DROP queries', () => {
       testFun: () => {
         expect(engine.hasNamedGraph(GRAPH_B_IRI)).to.equal(false)
       }
+    },
+    {
+      name: 'DROP DEFAULT',
+      query: `DROP DEFAULT`,
+      testFun: () => {
+        expect(engine.hasNamedGraph(GRAPH_A_IRI)).to.equal(false)
+        expect(engine.defaultGraphIRI()).to.equal(GRAPH_B_IRI)
+      }
     }
   ]
 

--- a/tests/update/drop-test.js
+++ b/tests/update/drop-test.js
@@ -59,7 +59,7 @@ describe('SPARQL UPDATE: DROP queries', () => {
       name: 'DROP ALL',
       query: `DROP ALL`,
       testFun: () => {
-        expect(engine._dataset.iris).to.equal(0)
+        expect(engine._dataset.iris.length).to.equal(0)
       }
     }
   ]

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -134,7 +134,7 @@ class TestEngine {
   }
 
   defaultGraphIRI() {
-    return this._defaultGraphIRI
+    return this._dataset.getDefaultGraph().iri
   }
 
   addNamedGraph(iri, db) {

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -145,6 +145,10 @@ class TestEngine {
     return this._dataset.getNamedGraph(iri)
   }
 
+  hasNamedGraph(iri) {
+    return this._dataset.hasNamedGraph(iri)
+  }
+
   execute(query, format = 'raw') {
     let iterator = this._builder.build(query)
     return iterator
@@ -153,5 +157,6 @@ class TestEngine {
 
 module.exports = {
   getGraph,
-  TestEngine
+  TestEngine,
+  N3Graph
 }

--- a/types/sparqljs/index.d.ts
+++ b/types/sparqljs/index.d.ts
@@ -166,6 +166,17 @@ declare module 'sparqljs' {
     }
 
     /**
+     * A SPARQL CREATE node
+     */
+    export interface UpdateCreateDropNode extends PlanNode {
+      silent: boolean;
+      graph: {
+        type: string,
+        name: string
+      };
+    }
+
+    /**
      * A SPARQL CLEAR node
      */
     export interface UpdateClearNode extends PlanNode {

--- a/types/sparqljs/index.d.ts
+++ b/types/sparqljs/index.d.ts
@@ -171,8 +171,9 @@ declare module 'sparqljs' {
     export interface UpdateCreateDropNode extends PlanNode {
       silent: boolean;
       graph: {
-        type: string,
-        name: string
+        default?: boolean;
+        type: string;
+        name: string;
       };
     }
 

--- a/types/sparqljs/index.d.ts
+++ b/types/sparqljs/index.d.ts
@@ -172,6 +172,7 @@ declare module 'sparqljs' {
       silent: boolean;
       graph: {
         default?: boolean;
+        all?: boolean;
         type: string;
         name: string;
       };


### PR DESCRIPTION
This PR adds the following features:
* Support for SPARQL Update [CREATE queries](https://www.w3.org/TR/2013/REC-sparql11-update-20130321/#create).
* Support for SPARQL Update [DROP queries](https://www.w3.org/TR/2013/REC-sparql11-update-20130321/#drop).
* Add tests for scenarios with both type of queries.