### PR TITLE
Add support for formatting JSON

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -71,5 +71,7 @@ export { default as RxjsPipeline } from './engine/pipeline/rxjs-pipeline'
 export { default as VectorPipeline } from './engine/pipeline/vector-pipeline'
 // RDF terms Utilities
 export { rdf } from './utils'
+// Formatters
+export { default as JsonFormat } from './formatters/json-formatter'
 
 export { stages }

--- a/src/formatters/json-formatter.ts
+++ b/src/formatters/json-formatter.ts
@@ -1,0 +1,61 @@
+/* file : json-formatter.ts
+MIT License
+
+Copyright (c) 2018-2020 Thomas Minier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+'use strict'
+
+import { PipelineStage } from '../engine/pipeline/pipeline-engine'
+import { Pipeline } from '../engine/pipeline/pipeline'
+import { Bindings } from '../rdf/bindings'
+import { rdf } from '../utils'
+import { Term } from 'rdf-js'
+import { map, isBoolean, isNull, isUndefined } from 'lodash'
+
+/**
+ * Formats query solutions (bindings or booleans) from a PipelineStage in W3C SPARQL JSON format
+ * @see https://www.w3.org/TR/2013/REC-sparql11-results-json-20130321/
+ * @author Thomas Minier
+ * @param source - Input pipeline
+ * @return A pipeline s-that yields results in W3C SPARQL XML format
+ */
+export default function jsonFormat (source: PipelineStage<Bindings | boolean>): PipelineStage<string> {
+  return Pipeline.getInstance().fromAsync(input => {
+
+    let warmup = true
+    source.subscribe((b: Bindings | boolean) => {
+      // Build the head attribute from the first set of bindings
+      if (warmup && !isBoolean(b)) {
+        
+        warmup = false
+      }
+      // handle results (boolean for ASK queries, bindings for SELECT queries)
+      if (isBoolean(b)) {
+        
+      } else {
+        
+      }
+    }, err => console.error(err), () => {
+      
+    })
+  })
+}

--- a/src/formatters/json-formatter.ts
+++ b/src/formatters/json-formatter.ts
@@ -24,38 +24,93 @@ SOFTWARE.
 
 'use strict'
 
-import { PipelineStage } from '../engine/pipeline/pipeline-engine'
+import { PipelineStage, StreamPipelineInput } from '../engine/pipeline/pipeline-engine'
 import { Pipeline } from '../engine/pipeline/pipeline'
 import { Bindings } from '../rdf/bindings'
 import { rdf } from '../utils'
-import { Term } from 'rdf-js'
-import { map, isBoolean, isNull, isUndefined } from 'lodash'
+import { isBoolean } from 'lodash'
+
+/**
+ * Write the JSON headers
+ * @private
+ * @param bindings - Input bindings
+ * @param input - Output where to write results
+ */
+function writeHead (bindings: Bindings, input: StreamPipelineInput<string>) {
+  const variables = Array.from(bindings.variables())
+  .map(v => v.startsWith('?') ? `"${v.substring(1)}"` : `"${v}"`)
+  .join(',')
+  input.next(`"head":{"vars": [${variables}]}`)
+}
+
+/**
+ * Write a set of bindings as JSON
+ * @private
+ * @param bindings - Input bindings
+ * @param input - Output where to write results
+ */
+function writeBindings (bindings: Bindings, input: StreamPipelineInput<string>): void {
+  let cpt = 0
+  bindings.forEach((variable, value) => {
+    if (cpt >= 1) {
+      input.next(',')
+    }
+    input.next(`"${variable.startsWith('?') ? variable.substring(1) : variable}":`)
+    const term = rdf.fromN3(value)
+    if (rdf.termIsIRI(term)) {
+      input.next(`{"type":"uri","value":"${term.value}"}`)
+    } else if (rdf.termIsBNode(term)) {
+      input.next(`{"type":"bnode","value":"${term.value}"}`)
+    } else if (rdf.termIsLiteral(term)) {
+      if (term.language.length > 0) {
+        input.next(`{"type":"literal","value":"${term.value}","xml:lang":"${term.language}"}`)
+      } else if (term.datatype) {
+        input.next(`{"type":"literal","value":"${term.value}","datatype":"${term.datatype.value}"}`)
+      } else {
+        input.next(`{"type":"literal","value":"${term.value}"}`)
+      }
+    } else {
+      input.error(`Invalid RDF term "${value}" encountered during JSON serialization`)
+    }
+    cpt++
+  })
+}
 
 /**
  * Formats query solutions (bindings or booleans) from a PipelineStage in W3C SPARQL JSON format
  * @see https://www.w3.org/TR/2013/REC-sparql11-results-json-20130321/
  * @author Thomas Minier
  * @param source - Input pipeline
- * @return A pipeline s-that yields results in W3C SPARQL XML format
+ * @return A pipeline that yields results in W3C SPARQL JSON format
  */
 export default function jsonFormat (source: PipelineStage<Bindings | boolean>): PipelineStage<string> {
   return Pipeline.getInstance().fromAsync(input => {
-
-    let warmup = true
+    input.next('{')
+    let cpt = 0
+    let isAsk = false
     source.subscribe((b: Bindings | boolean) => {
       // Build the head attribute from the first set of bindings
-      if (warmup && !isBoolean(b)) {
-        
-        warmup = false
+      if (cpt === 0 && !isBoolean(b)) {
+        writeHead(b, input)
+        input.next(',"results": {"bindings": [')
+      } else if (cpt === 0 && isBoolean(b)) {
+        isAsk = true
+        input.next('"boolean":')
+      } else if (cpt >= 1) {
+        input.next(',')
       }
       // handle results (boolean for ASK queries, bindings for SELECT queries)
       if (isBoolean(b)) {
-        
+        input.next(b ? 'true' : 'false')
       } else {
-        
+        input.next('{')
+        writeBindings(b, input)
+        input.next('}')
       }
+      cpt++
     }, err => console.error(err), () => {
-      
+      input.next(isAsk ? '}' : ']}}')
+      input.complete()
     })
   })
 }

--- a/tests/formatters/json-formatter-test.js
+++ b/tests/formatters/json-formatter-test.js
@@ -1,0 +1,82 @@
+/* file : json-formatter-test.js
+MIT License
+
+Copyright (c) 2018-2020 Thomas Minier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+'use strict'
+
+const expect = require('chai').expect
+const { getGraph, TestEngine } = require('../utils.js')
+const jsonFormatter = require('../../dist/formatters/json-formatter').default
+const expected = require('./select.json')
+
+describe('W3C JSON formatter', () => {
+  let engine = null
+  before(() => {
+    const g = getGraph('./tests/data/dblp.nt')
+    engine = new TestEngine(g)
+  })
+
+  it('should evaluate SELECT queries', done => {
+    const query = `
+    PREFIX dblp-pers: <https://dblp.org/pers/m/>
+    PREFIX dblp-rdf: <https://dblp.uni-trier.de/rdf/schema-2017-04-18#>
+    PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+    SELECT ?name ?article WHERE {
+      ?s rdf:type dblp-rdf:Person .
+      ?s dblp-rdf:primaryFullPersonName ?name .
+      ?s dblp-rdf:authorOf ?article .
+    }`
+    let results = ''
+    const iterator = engine.execute(query).pipe(jsonFormatter)
+    iterator.subscribe(b => {
+      results += b
+    }, done, () => {
+      const json = JSON.parse(results)
+      expect(json).to.deep.equals(expected)
+      done()
+    })
+  })
+
+  it('should evaluate ASK queries', done => {
+    const query = `
+    PREFIX dblp-pers: <https://dblp.org/pers/m/>
+    PREFIX dblp-rdf: <https://dblp.uni-trier.de/rdf/schema-2017-04-18#>
+    PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+    ASK {
+      ?s rdf:type dblp-rdf:Person .
+      ?s dblp-rdf:primaryFullPersonName ?name .
+      ?s dblp-rdf:authorOf ?article .
+    }`
+    let results = ''
+    const iterator = engine.execute(query).pipe(jsonFormatter)
+    iterator.subscribe(b => {
+      results += b
+    }, done, () => {
+      const json = JSON.parse(results)
+      expect(json).to.deep.equals({
+        boolean: true
+      })
+      done()
+    })
+  })
+})

--- a/tests/formatters/select.json
+++ b/tests/formatters/select.json
@@ -1,0 +1,67 @@
+{
+  "head": {
+    "vars": [
+      "name",
+      "article"
+    ]
+  },
+  "results": {
+    "bindings": [
+      {
+        "name": {
+          "type": "literal",
+          "value": "Thomas Minier",
+          "xml:lang": "en"
+        },
+        "article": {
+          "type": "uri",
+          "value": "https://dblp.org/rec/conf/esws/MinierMSM17a"
+        }
+      },
+      {
+        "name": {
+          "type": "literal",
+          "value": "Thomas Minier",
+          "xml:lang": "en"
+        },
+        "article": {
+          "type": "uri",
+          "value": "https://dblp.org/rec/conf/esws/MinierMSM17"
+        }
+      },
+      {
+        "name": {
+          "type": "literal",
+          "value": "Thomas Minier",
+          "xml:lang": "en"
+        },
+        "article": {
+          "type": "uri",
+          "value": "https://dblp.org/rec/journals/corr/abs-1806-00227"
+        }
+      },
+      {
+        "name": {
+          "type": "literal",
+          "value": "Thomas Minier",
+          "xml:lang": "en"
+        },
+        "article": {
+          "type": "uri",
+          "value": "https://dblp.org/rec/conf/esws/MinierSMV18"
+        }
+      },
+      {
+        "name": {
+          "type": "literal",
+          "value": "Thomas Minier",
+          "xml:lang": "en"
+        },
+        "article": {
+          "type": "uri",
+          "value": "https://dblp.org/rec/conf/esws/MinierSMV18a"
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
This PR adds the functionality to format query results to the [official W3C JSON format](https://www.w3.org/TR/2013/REC-sparql11-results-json-20130321/). The new function `JSONFormat` can be piped to an existing pipeline of bindings and used as follows
```typescript
import { JSONFormat } from 'sparql-engine'

// configure your datasets, graphs and the plan builder as usual

let pipeline = builder.execute(/* some SPARQL query */)

// plug-in the json formatter
pipeline = pipeline.pipe(JSONFormat)

// output results
pipeline.subscribe(console.log, console.error, () => console.log('done'))
```