### PR TITLE
Add support for formatting query results to CSV and TSV

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -73,5 +73,6 @@ export { default as VectorPipeline } from './engine/pipeline/vector-pipeline'
 export { rdf } from './utils'
 // Formatters
 export { default as JsonFormat } from './formatters/json-formatter'
+export { csvFormatter as CSVFormat, tsvFormatter as TSVFormat } from './formatters/csv-tsv-formatter'
 
 export { stages }

--- a/src/formatters/csv-tsv-formatter.ts
+++ b/src/formatters/csv-tsv-formatter.ts
@@ -1,0 +1,117 @@
+/* file : csv-tsv-formatter.ts
+MIT License
+
+Copyright (c) 2018-2020 Thomas Minier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+'use strict'
+
+import { PipelineStage, StreamPipelineInput } from '../engine/pipeline/pipeline-engine'
+import { Pipeline } from '../engine/pipeline/pipeline'
+import { Bindings } from '../rdf/bindings'
+import { isBoolean } from 'lodash'
+
+/**
+ * Write the headers and generate an ordering
+ * @private
+ * @param bindings - Input bindings
+ * @param separator - Separator to use
+ * @param input - Output where to write results
+ * @return The order of variables in the header
+ */
+function writeHead (bindings: Bindings, separator: string, input: StreamPipelineInput<string>): string[] {
+  const variables = Array.from(bindings.variables())
+    .map(v => v.startsWith('?') ? v.substring(1) : v)
+  input.next(variables.join(separator))
+  input.next('\n')
+  return variables
+}
+
+/**
+ * Write a set of bindings as CSV/TSV
+ * @private
+ * @param bindings - Input bindings
+ * @param separator - Separator to use
+ * @param input - Output where to write results
+ */
+function writeBindings (bindings: Bindings, separator: string, order: string[], input: StreamPipelineInput<string>): void {
+  let output: string[] = []
+  order.forEach(variable => {
+    if (bindings.has('?' + variable)) {
+      let value = bindings.get('?' + variable)!
+      output.push(value)
+    }
+  })
+  input.next(output.join(separator))
+}
+
+/**
+ * Create a function that formats query solutions in CSV/TSV using a separator
+ * @author Thomas Minier
+ * @param separator - Separator to use
+ * @return A function that formats query results in a pipeline fashion
+ */
+function genericFormatter (separator: string) {
+  return (source: PipelineStage<Bindings | boolean>): PipelineStage<string> => {
+    return Pipeline.getInstance().fromAsync(input => {
+      let warmup = true
+      let isAsk = false
+      let ordering: string[] = []
+      source.subscribe((b: Bindings | boolean) => {
+        // Build the head attribute from the first set of bindings
+        if (warmup && !isBoolean(b)) {
+          ordering = writeHead(b, separator, input)
+        } else if (warmup && isBoolean(b)) {
+          isAsk = true
+          input.next('boolean\n')
+        }
+        warmup = false
+        // handle results (boolean for ASK queries, bindings for SELECT queries)
+        if (isBoolean(b)) {
+          input.next(b ? 'true\n' : 'false\n')
+        } else {
+          writeBindings(b, separator, ordering, input)
+          input.next('\n')
+        }
+      }, err => console.error(err), () => {
+        input.complete()
+      })
+    })
+  }
+}
+
+/**
+ * Formats query solutions (bindings or booleans) from a PipelineStage in W3C SPARQL CSV format
+ * @see https://www.w3.org/TR/2013/REC-sparql11-results-csv-tsv-20130321/
+ * @author Thomas Minier
+ * @param source - Input pipeline
+ * @return A pipeline that yields results in W3C SPARQL CSV format
+ */
+export const csvFormatter = genericFormatter(',')
+
+/**
+ * Formats query solutions (bindings or booleans) from a PipelineStage in W3C SPARQL TSV format
+ * @see https://www.w3.org/TR/2013/REC-sparql11-results-csv-tsv-20130321/
+ * @author Thomas Minier
+ * @param source - Input pipeline
+ * @return A pipeline that yields results in W3C SPARQL TSV format
+ */
+export const tsvFormatter = genericFormatter('\t')

--- a/tests/formatters/csv-formatter-test.js
+++ b/tests/formatters/csv-formatter-test.js
@@ -1,0 +1,87 @@
+/* file : csv-formatter-test.js
+MIT License
+
+Copyright (c) 2018-2020 Thomas Minier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+'use strict'
+
+const expect = require('chai').expect
+const { getGraph, TestEngine } = require('../utils.js')
+const { csvFormatter } = require('../../dist/formatters/csv-tsv-formatter')
+
+describe('W3C CSV formatter', () => {
+  let engine = null
+  before(() => {
+    const g = getGraph('./tests/data/dblp.nt')
+    engine = new TestEngine(g)
+  })
+
+  it('should evaluate SELECT queries', done => {
+    const query = `
+    PREFIX dblp-pers: <https://dblp.org/pers/m/>
+    PREFIX dblp-rdf: <https://dblp.uni-trier.de/rdf/schema-2017-04-18#>
+    PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+    SELECT ?name ?article WHERE {
+      ?s rdf:type dblp-rdf:Person .
+      ?s dblp-rdf:primaryFullPersonName ?name .
+      ?s dblp-rdf:authorOf ?article .
+    }`
+    let results = ''
+    const expected = `name,article
+"Thomas Minier"@en,https://dblp.org/rec/conf/esws/MinierMSM17a
+"Thomas Minier"@en,https://dblp.org/rec/conf/esws/MinierMSM17
+"Thomas Minier"@en,https://dblp.org/rec/journals/corr/abs-1806-00227
+"Thomas Minier"@en,https://dblp.org/rec/conf/esws/MinierSMV18
+"Thomas Minier"@en,https://dblp.org/rec/conf/esws/MinierSMV18a
+`
+    const iterator = engine.execute(query).pipe(csvFormatter)
+    iterator.subscribe(b => {
+      results += b
+    }, done, () => {
+      expect(results).to.equals(expected)
+      done()
+    })
+  })
+
+  it('should evaluate ASK queries', done => {
+    const query = `
+    PREFIX dblp-pers: <https://dblp.org/pers/m/>
+    PREFIX dblp-rdf: <https://dblp.uni-trier.de/rdf/schema-2017-04-18#>
+    PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+    ASK {
+      ?s rdf:type dblp-rdf:Person .
+      ?s dblp-rdf:primaryFullPersonName ?name .
+      ?s dblp-rdf:authorOf ?article .
+    }`
+    let results = ''
+    const iterator = engine.execute(query).pipe(csvFormatter)
+    const expected = `boolean
+true
+`
+    iterator.subscribe(b => {
+      results += b
+    }, done, () => {
+      expect(results).to.equals(expected)
+      done()
+    })
+  })
+})

--- a/tests/formatters/tsv-formatter-test.js
+++ b/tests/formatters/tsv-formatter-test.js
@@ -1,0 +1,87 @@
+/* file : tsv-formatter-test.js
+MIT License
+
+Copyright (c) 2018-2020 Thomas Minier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+'use strict'
+
+const expect = require('chai').expect
+const { getGraph, TestEngine } = require('../utils.js')
+const { tsvFormatter } = require('../../dist/formatters/csv-tsv-formatter')
+
+describe('W3C TSV formatter', () => {
+  let engine = null
+  before(() => {
+    const g = getGraph('./tests/data/dblp.nt')
+    engine = new TestEngine(g)
+  })
+
+  it('should evaluate SELECT queries', done => {
+    const query = `
+    PREFIX dblp-pers: <https://dblp.org/pers/m/>
+    PREFIX dblp-rdf: <https://dblp.uni-trier.de/rdf/schema-2017-04-18#>
+    PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+    SELECT ?name ?article WHERE {
+      ?s rdf:type dblp-rdf:Person .
+      ?s dblp-rdf:primaryFullPersonName ?name .
+      ?s dblp-rdf:authorOf ?article .
+    }`
+    let results = ''
+    const expected = `name\tarticle
+"Thomas Minier"@en\thttps://dblp.org/rec/conf/esws/MinierMSM17a
+"Thomas Minier"@en\thttps://dblp.org/rec/conf/esws/MinierMSM17
+"Thomas Minier"@en\thttps://dblp.org/rec/journals/corr/abs-1806-00227
+"Thomas Minier"@en\thttps://dblp.org/rec/conf/esws/MinierSMV18
+"Thomas Minier"@en\thttps://dblp.org/rec/conf/esws/MinierSMV18a
+`
+    const iterator = engine.execute(query).pipe(tsvFormatter)
+    iterator.subscribe(b => {
+      results += b
+    }, done, () => {
+      expect(results).to.equals(expected)
+      done()
+    })
+  })
+
+  it('should evaluate ASK queries', done => {
+    const query = `
+    PREFIX dblp-pers: <https://dblp.org/pers/m/>
+    PREFIX dblp-rdf: <https://dblp.uni-trier.de/rdf/schema-2017-04-18#>
+    PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+    ASK {
+      ?s rdf:type dblp-rdf:Person .
+      ?s dblp-rdf:primaryFullPersonName ?name .
+      ?s dblp-rdf:authorOf ?article .
+    }`
+    let results = ''
+    const iterator = engine.execute(query).pipe(tsvFormatter)
+    const expected = `boolean
+true
+`
+    iterator.subscribe(b => {
+      results += b
+    }, done, () => {
+      expect(results).to.equals(expected)
+      done()
+    })
+  })
+})


### PR DESCRIPTION
This PR adds the functionality to format query results to the [official W3C CSV and TSV formats](https://www.w3.org/TR/2013/REC-sparql11-results-csv-tsv-20130321/). The new functions `CSVFormat` and `TSVFormat` can be piped to an existing pipeline of bindings and used as follows
```typescript
import { CSVFormat } from 'sparql-engine'

// configure your datasets, graphs and the plan builder as usual

let pipeline = builder.execute(/* some SPARQL query */)

// plug-in the csv formatter
pipeline = pipeline.pipe(CSVFormat)

// output results
pipeline.subscribe(console.log, console.error, () => console.log('done'))
```