### PR TITLE
fix: Property paths' object is using wrong binding

### DIFF
--- a/src/engine/stages/path-stage-builder.ts
+++ b/src/engine/stages/path-stage-builder.ts
@@ -48,7 +48,7 @@ function boundPathTriple (triple: Algebra.PathTripleObject, bindings: Bindings):
     t.subject = bindings.get(triple.subject)!
   }
   if (triple.object.startsWith('?') && bindings.has(triple.object)) {
-    t.object = bindings.get(triple.subject)!
+    t.object = bindings.get(triple.object)!
   }
   return t
 }

--- a/tests/paths/alternative-test.js
+++ b/tests/paths/alternative-test.js
@@ -134,10 +134,36 @@ describe('SPARQL property paths: alternative paths', () => {
                 case 'http://example.org/Carol':
                     expect(b['?o']).to.be.oneOf(['tel:0645123549'])
                     break;
-            }            
+            }
             results.push(b)
         }, done, () => {
             expect(results.length).to.equal(6)
+            done()
+        })
+    });
+
+    it('should evaluate property paths with bound variables within a group', done => {
+        const query = `
+        PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+        PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+        PREFIX : <http://example.org/>
+
+        ASK WHERE {
+          BIND(:Alice as ?foo).
+          BIND(:Bob as ?bar).
+
+          {
+            ?foo foaf:knows | :hate ?bar.
+          }
+        }`;
+
+        const results = []
+        const iterator = engine.execute(query)
+        iterator.subscribe(b => {
+            results.push(b)
+        }, done, () => {
+            expect(results.length).to.equal(1);
+            expect(results[0]).to.equal(true);
             done()
         })
     })


### PR DESCRIPTION
~I have added a test for something that should actually be working: I don't know what is the best way of fixing it yet, I'd love to have some guidance if possible.~

Fixes a bug with the property paths.

FYI @Lastshot97 as you contributed the property path engine.