### PR TITLE
perf: When property path is bound both sides, use both bindings

### DIFF
--- a/src/engine/stages/glushkov-executor/glushkov-stage-builder.ts
+++ b/src/engine/stages/glushkov-executor/glushkov-stage-builder.ts
@@ -278,14 +278,16 @@ export default class GlushkovStageBuilder extends PathStageBuilder {
     let obs: PipelineStage<Algebra.TripleObject>[] = transitions.map(transition => {
       let reverse = (forward && transition.reverse) || (!forward && !transition.reverse)
       let bgp: Array<Algebra.TripleObject> = [ {
-        subject: reverse ? '?o' : subject,
+        subject: reverse ? (rdf.isVariable(obj) ? '?o' : obj) : subject,
         predicate: transition.negation ? '?p' : transition.predicates[0],
-        object: reverse ? subject : '?o'
+        object: reverse ? subject : (rdf.isVariable(obj) ? '?o' : obj)
       }]
+
       return engine.mergeMap(engine.from(graph.evalBGP(bgp, context)), (binding: Bindings) => {
         let s = (rdf.isVariable(subject) ? binding.get(subject) : subject) as string
         let p = binding.get('?p')
-        let o = binding.get('?o') as string
+        let o = rdf.isVariable(obj) ? binding.get('?o') as string : obj
+
         if (p !== null ? !transition.hasPredicate(p) : true) {
           let path = new ResultPath()
           if (forward) {

--- a/tests/paths/alternative-test.js
+++ b/tests/paths/alternative-test.js
@@ -176,4 +176,28 @@ describe('SPARQL property paths: alternative paths', () => {
             done()
         })
     })
+
+    it('should evaluate property paths with bound values both sides with the simplest query', done => {
+        const query = `
+        PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+        PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+        PREFIX : <http://example.org/>
+
+        ASK WHERE {
+          {
+            :Alice foaf:knows | :hate :Bob.
+          }
+        }`;
+
+
+        const results = []
+        const iterator = engine.execute(query)
+        iterator.subscribe(b => {
+            results.push(b)
+        }, done, () => {
+            expect(results.length).to.equal(1);
+            expect(results[0]).to.equal(true);
+            done()
+        })
+    })
 })


### PR DESCRIPTION
At the moment, even if both sides of the property path are bound, the triple match will have one side unbound: this is a performance bottleneck, especially for large datasets.

This PR changes this.